### PR TITLE
feat(release): Add convenience functions around creating releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:
-  - format: zip
+  - formats: ['zip']
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
@@ -56,8 +56,8 @@ release:
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  # Publish manually post review
-  draft: true
+  # Automatically publish tagged releases
+  draft: false
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PLAYGROUND_TFRC ?= $(PLAYGROUND_DIR)/terraformrc
 PLUGIN_FILENAME ?= terraform-provider-$(PLUGIN_NAME)_v$(PLUGIN_VERSION)
 
 default: fmt lint install generate
-.PHONY: fmt lint test testacc build install generate playground-binary playground-init playground-plan playground-apply playground-clean
+.PHONY: fmt lint test testacc build install generate playground-binary playground-init playground-plan playground-apply playground-clean release-alpha release-beta release
 
 build:
 	go build -v ./...
@@ -64,3 +64,27 @@ playground-apply: playground-tfrc
 playground-clean:
 	rm -f $(PLAYGROUND_TFRC)
 	rm -rf $(PLAYGROUND_DIR)/.terraform $(PLAYGROUND_DIR)/.terraform.lock.hcl
+
+# Release targets - create signed tags and push to trigger GoReleaser
+# Usage: make release-alpha VERSION=0.1.0 NUM=1  -> v0.1.0-alpha.1
+#        make release VERSION=0.1.0              -> v0.1.0
+VERSION ?= 0.0.1
+NUM ?= 1
+
+release-alpha:
+	@echo "Creating alpha release v$(VERSION)-alpha.$(NUM)..."
+	git tag -s "v$(VERSION)-alpha.$(NUM)" -m "v$(VERSION)-alpha.$(NUM)"
+	git push origin "v$(VERSION)-alpha.$(NUM)"
+	@echo "Release v$(VERSION)-alpha.$(NUM) pushed. Check GitHub Actions for release status."
+
+release-beta:
+	@echo "Creating beta release v$(VERSION)-beta.$(NUM)..."
+	git tag -s "v$(VERSION)-beta.$(NUM)" -m "v$(VERSION)-beta.$(NUM)"
+	git push origin "v$(VERSION)-beta.$(NUM)"
+	@echo "Release v$(VERSION)-beta.$(NUM) pushed. Check GitHub Actions for release status."
+
+release:
+	@echo "Creating stable release v$(VERSION)..."
+	git tag -s "v$(VERSION)" -m "v$(VERSION)"
+	git push origin "v$(VERSION)"
+	@echo "Release v$(VERSION) pushed. Check GitHub Actions for release status."

--- a/README.md
+++ b/README.md
@@ -99,3 +99,24 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 ```shell
 make testacc
 ```
+
+## Releasing
+
+Releases are automated via GoReleaser when a signed tag is pushed. The Makefile provides convenience targets for creating releases:
+
+```shell
+# Alpha releases (pre-release, for early testing)
+make release-alpha VERSION=0.1.0 NUM=1  # creates v0.1.0-alpha.1
+
+# Beta releases (pre-release, feature complete)
+make release-beta VERSION=0.1.0 NUM=1   # creates v0.1.0-beta.1
+
+# Stable releases
+make release VERSION=0.1.0              # creates v0.1.0
+```
+
+**Requirements:**
+- GPG key configured for signing (`git tag -s`)
+- GPG key added to your GitHub account (for the "Verified" badge)
+
+Pre-release versions (alpha, beta) won't be installed by default — users must explicitly pin to them in their Terraform configuration.


### PR DESCRIPTION
This allows us to easily create releases by running the make targets like so:

```
 make release-alpha VERSION=0.0.1 NUM=4
 ```