### PR TITLE
fix: preserve user-configured tags when API returns empty

### DIFF
--- a/internal/resource/dashboard.go
+++ b/internal/resource/dashboard.go
@@ -134,7 +134,8 @@ func (o DashboardOps) MapResponseToModel(ctx context.Context, resp httpclient.Da
 	model.Pinned = core.PtrToBool(resp.Pinned)
 	model.Deleted = core.PtrToBool(resp.Deleted)
 
-	tagsSet, d := core.TagsToSet(ctx, resp.Tags)
+	// Tags - preserve user's configured tags if API returns empty
+	tagsSet, d := core.TagsToSetPreserveEmpty(ctx, resp.Tags, model.Tags)
 	diags.Append(d...)
 	model.Tags = tagsSet
 

--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -248,8 +248,8 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 		model.RolloutPercentage = types.Int64Null()
 	}
 
-	// Set tags
-	tagsSet, d := core.TagsToSet(ctx, resp.Tags)
+	// Set tags - preserve user's configured tags if API returns empty
+	tagsSet, d := core.TagsToSetPreserveEmpty(ctx, resp.Tags, model.Tags)
 	diags.Append(d...)
 	model.Tags = tagsSet
 

--- a/testacc/dashboard_test.go
+++ b/testacc/dashboard_test.go
@@ -93,6 +93,8 @@ func TestDashboard_Update(t *testing.T) {
 }
 
 // TestDashboard_Tags tests creating, updating, and removing tags.
+// This test verifies the fix for the "Provider produced inconsistent result after apply" error
+// where tags were being returned as null after creation/update.
 func TestDashboard_Tags(t *testing.T) {
 	skipIfNotAcceptance(t)
 
@@ -102,11 +104,13 @@ func TestDashboard_Tags(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create with tags
+			// Create with tags - verify both count and specific values
 			{
 				Config: testAccDashboardWithTags(rName, []string{"tag1", "tag2"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_dashboard.test", "tags.#", "2"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag1"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag2"),
 				),
 			},
 			// Add more tags
@@ -114,6 +118,9 @@ func TestDashboard_Tags(t *testing.T) {
 				Config: testAccDashboardWithTags(rName, []string{"tag1", "tag2", "tag3"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_dashboard.test", "tags.#", "3"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag1"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag2"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag3"),
 				),
 			},
 			// Remove tags
@@ -121,6 +128,7 @@ func TestDashboard_Tags(t *testing.T) {
 				Config: testAccDashboardWithTags(rName, []string{"tag1"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_dashboard.test", "tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr("posthog_dashboard.test", "tags.*", "tag1"),
 				),
 			},
 		},

--- a/testacc/insight_test.go
+++ b/testacc/insight_test.go
@@ -198,6 +198,8 @@ func TestInsight_Update(t *testing.T) {
 }
 
 // TestInsight_Tags tests creating, updating, and removing tags.
+// This test verifies the fix for the "Provider produced inconsistent result after apply" error
+// where tags were being returned as null/empty after creation/update.
 func TestInsight_Tags(t *testing.T) {
 	skipIfNotAcceptance(t)
 
@@ -207,11 +209,13 @@ func TestInsight_Tags(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create with tags
+			// Create with tags - verify both count and specific values
 			{
 				Config: testAccInsightWithTags(rName, []string{"tag1", "tag2"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_insight.test", "tags.#", "2"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag1"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag2"),
 				),
 			},
 			// Add more tags
@@ -219,6 +223,9 @@ func TestInsight_Tags(t *testing.T) {
 				Config: testAccInsightWithTags(rName, []string{"tag1", "tag2", "tag3"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_insight.test", "tags.#", "3"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag1"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag2"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag3"),
 				),
 			},
 			// Remove tags
@@ -226,6 +233,7 @@ func TestInsight_Tags(t *testing.T) {
 				Config: testAccInsightWithTags(rName, []string{"tag1"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("posthog_insight.test", "tags.#", "1"),
+					resource.TestCheckTypeSetElemAttr("posthog_insight.test", "tags.*", "tag1"),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

## Changes

## Proof of work

❌ **Apply fails without these code changes**

```hcl
resource "posthog_dashboard" "test" {
  name = "Test Dashboard"
  tags = ["test-tag"]  
}
```

<img width="1784" height="1502" alt="CleanShot 2026-01-21 at 10 16 35@2x" src="https://github.com/user-attachments/assets/77a7a111-fdd1-432d-a5f3-2e3843f4ac3f" />


✅ **Apply works with these code changes**
<img width="1792" height="1492" alt="CleanShot 2026-01-21 at 09 12 46@2x" src="https://github.com/user-attachments/assets/6f24dd8d-4337-4e92-903f-608836f9bdfc" />

