### PR TITLE
chore: update test expectations after introducing access config on default lvls

### DIFF
--- a/internal/httpclient/access_control_test.go
+++ b/internal/httpclient/access_control_test.go
@@ -56,12 +56,12 @@ func TestAccessControl_BuildCompositeID(t *testing.T) {
 			},
 			expected: "proj-123/feature_flag/role/role-456",
 		},
-		"nil role and member returns empty": {
+		"nil role and member returns project default": {
 			projectID: "proj-123",
 			ac: AccessControl{
 				Resource: "dashboard",
 			},
-			expected: "",
+			expected: "proj-123/dashboard/default",
 		},
 	}
 


### PR DESCRIPTION
## Description

After merging https://github.com/PostHog/terraform-provider-posthog/pull/35 I noticed that the test job failed, and that it was missed as the doc update commit from the gh action caused the ci to look green.

Upon inspection it turned out that it failed due to the test being missed when we introduced access controls for the project defaults (and as such changed the import logic).  

The ci is now green again after updating the test to align with the updated logic.

