### PR TITLE
feat: add inputs_schema_json to posthog_hog_function resource

### DIFF
--- a/docs/resources/hog_function.md
+++ b/docs/resources/hog_function.md
@@ -24,6 +24,7 @@ Manage PostHog Hog functions. Hog functions enable destinations, webhooks, and t
 - `hog` (String) The Hog code to execute. Not required when using a template - the template provides the code.
 - `icon_url` (String) URL of the icon for this Hog function.
 - `inputs_json` (String) JSON object containing the input values for the Hog function. Keys correspond to the input schema, values contain `value` and optional `templating` properties. For inputs containing secrets, use `sensitive_inputs_json` instead.
+- `inputs_schema_json` (String) JSON array defining custom input schema entries for the Hog function. Each entry is an object with `key`, `type`, `secret`, `required`, and other properties. Sent directly as `inputs_schema` in the API request. When using a template, this replaces the template's default schema.
 - `mappings_json` (String) JSON array of mapping configurations. Each mapping can have its own `name`, `inputs_schema`, `inputs`, and `filters`.
 - `masking_json` (String) JSON object configuring PII masking for the Hog function. Includes `ttl`, `threshold`, and `hash` properties.
 - `name` (String) Name of the Hog function.

--- a/internal/resource/hog_function.go
+++ b/internal/resource/hog_function.go
@@ -35,6 +35,7 @@ type HogFunctionResourceTFModel struct {
 	Hog                 types.String `tfsdk:"hog"`
 	InputsJSON          types.String `tfsdk:"inputs_json"`
 	SensitiveInputsJSON types.String `tfsdk:"sensitive_inputs_json"`
+	InputsSchemaJSON    types.String `tfsdk:"inputs_schema_json"`
 	FiltersJSON         types.String `tfsdk:"filters_json"`
 	MaskingJSON         types.String `tfsdk:"masking_json"`
 	MappingsJSON        types.String `tfsdk:"mappings_json"`
@@ -101,6 +102,10 @@ func (o HogFunctionOps) Schema() schema.Schema {
 				Optional:            true,
 				Sensitive:           true,
 				MarkdownDescription: "JSON object containing sensitive input values (e.g. API keys, tokens, credentials) for the Hog function. Same format as `inputs_json`. Values are merged with `inputs_json` at apply time and redacted from plan/apply output. If the same key appears in both, `sensitive_inputs_json` takes precedence.",
+			},
+			"inputs_schema_json": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "JSON array defining custom input schema entries for the Hog function. Each entry is an object with `key`, `type`, `secret`, `required`, and other properties. Sent directly as `inputs_schema` in the API request. When using a template, this replaces the template's default schema.",
 			},
 			"filters_json": schema.StringAttribute{
 				Optional:            true,
@@ -211,6 +216,18 @@ func (o HogFunctionOps) BuildCreateRequest(ctx context.Context, model HogFunctio
 					req.Inputs[k] = v
 				}
 			}
+		}
+	}
+
+	if !model.InputsSchemaJSON.IsNull() && !model.InputsSchemaJSON.IsUnknown() {
+		raw := strings.TrimSpace(model.InputsSchemaJSON.ValueString())
+		if raw != "" {
+			var inputsSchema []map[string]interface{}
+			if err := json.Unmarshal([]byte(raw), &inputsSchema); err != nil {
+				diags.AddError("Invalid inputs_schema_json", "inputs_schema_json must be a valid JSON array: "+err.Error())
+				return req, diags
+			}
+			req.InputsSchema = inputsSchema
 		}
 	}
 
@@ -335,6 +352,40 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 		if !model.SensitiveInputsJSON.IsNull() {
 			model.SensitiveInputsJSON = types.StringValue("{}")
 		}
+	}
+
+	// Filter inputs_schema to only entries the user specified (by "key" field)
+	if len(resp.InputsSchema) > 0 {
+		if !model.InputsSchemaJSON.IsNull() {
+			var userSchema []map[string]interface{}
+			if err := json.Unmarshal([]byte(model.InputsSchemaJSON.ValueString()), &userSchema); err != nil {
+				diags.AddError("Failed to parse inputs_schema_json from state", err.Error())
+				return diags
+			}
+			userKeys := make(map[string]bool)
+			for _, entry := range userSchema {
+				if key, ok := entry["key"].(string); ok {
+					userKeys[key] = true
+				}
+			}
+			var filtered []map[string]interface{}
+			for _, entry := range resp.InputsSchema {
+				if key, ok := entry["key"].(string); ok && userKeys[key] {
+					filtered = append(filtered, entry)
+				}
+			}
+			if filtered == nil {
+				filtered = []map[string]interface{}{}
+			}
+			data, err := json.Marshal(filtered)
+			if err != nil {
+				diags.AddError("Failed to marshal inputs_schema", err.Error())
+				return diags
+			}
+			model.InputsSchemaJSON = types.StringValue(string(data))
+		}
+	} else if !model.InputsSchemaJSON.IsNull() {
+		model.InputsSchemaJSON = types.StringValue("[]")
 	}
 
 	if len(resp.Filters) > 0 {

--- a/internal/resource/hog_function_test.go
+++ b/internal/resource/hog_function_test.go
@@ -39,6 +39,20 @@ func TestHogFunctionSchema_InputsJSONIsNotSensitive(t *testing.T) {
 		"inputs_json should NOT be sensitive - use sensitive_inputs_json for secrets")
 }
 
+func TestHogFunctionSchema_InputsSchemaJSONExists(t *testing.T) {
+	ops := HogFunctionOps{}
+	s := ops.Schema()
+
+	attr, ok := s.Attributes["inputs_schema_json"]
+	require.True(t, ok, "inputs_schema_json attribute must exist in schema")
+
+	strAttr, ok := attr.(schema.StringAttribute)
+	require.True(t, ok, "inputs_schema_json must be a StringAttribute")
+
+	assert.True(t, strAttr.Optional, "inputs_schema_json must be optional")
+	assert.False(t, strAttr.Sensitive, "inputs_schema_json should not be sensitive")
+}
+
 func TestBuildCreateRequest_MergesSensitiveInputs(t *testing.T) {
 	ctx := context.Background()
 	tests := map[string]struct {
@@ -100,6 +114,125 @@ func TestBuildCreateRequest_MergesSensitiveInputs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildCreateRequest_InputsSchemaJSON(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	tests := map[string]struct {
+		inputsSchemaJSON string
+		expectedLen      int
+		expectedKey      string
+	}{
+		"parses inputs_schema_json into request": {
+			inputsSchemaJSON: `[{"key":"apiKey","type":"string","secret":true,"required":true}]`,
+			expectedLen:      1,
+			expectedKey:      "apiKey",
+		},
+		"multiple schema entries": {
+			inputsSchemaJSON: `[{"key":"apiKey","type":"string","secret":true},{"key":"region","type":"string"}]`,
+			expectedLen:      2,
+			expectedKey:      "apiKey",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			model := HogFunctionResourceTFModel{
+				InputsSchemaJSON: types.StringValue(tc.inputsSchemaJSON),
+			}
+
+			req, diags := ops.BuildCreateRequest(ctx, model)
+			require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+			require.Len(t, req.InputsSchema, tc.expectedLen)
+			assert.Equal(t, tc.expectedKey, req.InputsSchema[0]["key"])
+		})
+	}
+}
+
+func TestBuildCreateRequest_InputsSchemaJSON_Invalid(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	model := HogFunctionResourceTFModel{
+		InputsSchemaJSON: types.StringValue(`not valid json`),
+	}
+
+	_, diags := ops.BuildCreateRequest(ctx, model)
+	require.True(t, diags.HasError(), "expected error for invalid JSON")
+}
+
+func TestBuildCreateRequest_InputsSchemaJSON_Null(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	model := HogFunctionResourceTFModel{
+		InputsSchemaJSON: types.StringNull(),
+	}
+
+	req, diags := ops.BuildCreateRequest(ctx, model)
+	require.False(t, diags.HasError())
+	assert.Nil(t, req.InputsSchema)
+}
+
+func TestBuildCreateRequest_InputsSchemaWithInputsAndSensitiveInputs(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	t.Run("all three fields populate request correctly", func(t *testing.T) {
+		model := HogFunctionResourceTFModel{
+			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true,"required":true}]`),
+		}
+
+		req, diags := ops.BuildCreateRequest(ctx, model)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		// Schema is set
+		require.Len(t, req.InputsSchema, 1)
+		assert.Equal(t, "apiKey", req.InputsSchema[0]["key"])
+		assert.Equal(t, true, req.InputsSchema[0]["secret"])
+
+		// Both inputs merged (sensitive takes precedence)
+		assert.Contains(t, req.Inputs, "url")
+		assert.Contains(t, req.Inputs, "apiKey")
+		apiKey := req.Inputs["apiKey"].(map[string]interface{})
+		assert.Equal(t, "secret-token", apiKey["value"])
+	})
+
+	t.Run("schema with inputs_json only (no sensitive)", func(t *testing.T) {
+		model := HogFunctionResourceTFModel{
+			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"},"region":{"value":"us-east-1"}}`),
+			SensitiveInputsJSON: types.StringNull(),
+			InputsSchemaJSON:    types.StringValue(`[{"key":"region","type":"string"}]`),
+		}
+
+		req, diags := ops.BuildCreateRequest(ctx, model)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		require.Len(t, req.InputsSchema, 1)
+		assert.Equal(t, "region", req.InputsSchema[0]["key"])
+		assert.Contains(t, req.Inputs, "url")
+		assert.Contains(t, req.Inputs, "region")
+	})
+
+	t.Run("schema with sensitive_inputs_json only (no inputs_json)", func(t *testing.T) {
+		model := HogFunctionResourceTFModel{
+			InputsJSON:          types.StringNull(),
+			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+		}
+
+		req, diags := ops.BuildCreateRequest(ctx, model)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		require.Len(t, req.InputsSchema, 1)
+		assert.Equal(t, "apiKey", req.InputsSchema[0]["key"])
+		assert.Contains(t, req.Inputs, "apiKey")
+	})
 }
 
 func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
@@ -211,6 +344,129 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 	}
 }
 
+func TestMapResponseToModel_InputsSchemaJSON(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	tests := map[string]struct {
+		inputsSchemaJSON types.String
+		respInputsSchema []map[string]interface{}
+		expectedJSON     string
+		expectNull       bool
+	}{
+		"filters to user-specified keys": {
+			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+			respInputsSchema: []map[string]interface{}{
+				{"key": "url", "type": "string", "label": "URL"},
+				{"key": "apiKey", "type": "string", "secret": true, "label": "API Key"},
+				{"key": "method", "type": "string", "label": "Method"},
+			},
+			expectedJSON: `[{"key":"apiKey","label":"API Key","secret":true,"type":"string"}]`,
+		},
+		"null stays null on import": {
+			inputsSchemaJSON: types.StringNull(),
+			respInputsSchema: []map[string]interface{}{
+				{"key": "url", "type": "string"},
+			},
+			expectNull: true,
+		},
+		"empty response with non-null model": {
+			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"}]`),
+			respInputsSchema: nil,
+			expectedJSON:     "[]",
+		},
+		"multiple user keys filtered from larger response": {
+			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"},{"key":"region","type":"string"}]`),
+			respInputsSchema: []map[string]interface{}{
+				{"key": "url", "type": "string"},
+				{"key": "apiKey", "type": "string", "secret": true},
+				{"key": "method", "type": "string"},
+				{"key": "region", "type": "string", "default": "us-east-1"},
+			},
+			expectedJSON: `[{"key":"apiKey","secret":true,"type":"string"},{"default":"us-east-1","key":"region","type":"string"}]`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			model := &HogFunctionResourceTFModel{
+				InputsSchemaJSON: tc.inputsSchemaJSON,
+			}
+
+			resp := httpclient.HogFunction{
+				ID:           "test-id",
+				InputsSchema: tc.respInputsSchema,
+			}
+
+			diags := ops.MapResponseToModel(ctx, resp, model)
+			require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+			if tc.expectNull {
+				assert.True(t, model.InputsSchemaJSON.IsNull())
+			} else {
+				assert.Equal(t, tc.expectedJSON, model.InputsSchemaJSON.ValueString())
+			}
+		})
+	}
+}
+
+func TestMapResponseToModel_InputsSchemaJSON_InvalidState(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	model := &HogFunctionResourceTFModel{
+		InputsSchemaJSON: types.StringValue(`not valid json`),
+	}
+
+	resp := httpclient.HogFunction{
+		ID: "test-id",
+		InputsSchema: []map[string]interface{}{
+			{"key": "apiKey", "type": "string"},
+		},
+	}
+
+	diags := ops.MapResponseToModel(ctx, resp, model)
+	require.True(t, diags.HasError(), "expected error for invalid JSON in state")
+}
+
+func TestMapResponseToModel_InputsSchemaWithInputsAndSensitiveInputs(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	t.Run("all three fields round-trip correctly", func(t *testing.T) {
+		model := &HogFunctionResourceTFModel{
+			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+		}
+
+		resp := httpclient.HogFunction{
+			ID: "test-id",
+			InputsSchema: []map[string]interface{}{
+				{"key": "url", "type": "string", "label": "URL"},
+				{"key": "method", "type": "string", "label": "Method"},
+				{"key": "apiKey", "type": "string", "secret": true, "label": "API Key"},
+			},
+			Inputs: map[string]interface{}{
+				"url":    map[string]interface{}{"value": "https://example.com"},
+				"apiKey": map[string]interface{}{"value": "secret-token"},
+			},
+		}
+
+		diags := ops.MapResponseToModel(ctx, resp, model)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		// Schema filtered to user-specified key only
+		assert.Equal(t, `[{"key":"apiKey","label":"API Key","secret":true,"type":"string"}]`, model.InputsSchemaJSON.ValueString())
+
+		// inputs_json filtered to user-specified key
+		assert.Equal(t, `{"url":{"value":"https://example.com"}}`, model.InputsJSON.ValueString())
+
+		// sensitive_inputs_json filtered to user-specified key
+		assert.Equal(t, `{"apiKey":{"value":"secret-token"}}`, model.SensitiveInputsJSON.ValueString())
+	})
+}
+
 func TestBuildUpdateRequest_SensitiveInputs(t *testing.T) {
 	ctx := context.Background()
 	ops := HogFunctionOps{}
@@ -249,6 +505,40 @@ func TestBuildUpdateRequest_SensitiveInputs(t *testing.T) {
 		assert.Contains(t, req.Inputs, "api_key")
 		apiKey := req.Inputs["api_key"].(map[string]interface{})
 		assert.Equal(t, "new_secret", apiKey["value"], "should use the new secret value")
+	})
+}
+
+func TestBuildUpdateRequest_InputsSchemaJSON(t *testing.T) {
+	ctx := context.Background()
+	ops := HogFunctionOps{}
+
+	t.Run("inputs_schema_json flows through update", func(t *testing.T) {
+		plan := HogFunctionResourceTFModel{
+			InputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+		}
+		state := HogFunctionResourceTFModel{
+			InputsSchemaJSON: types.StringValue(`[{"key":"oldKey","type":"string"}]`),
+		}
+
+		req, diags := ops.BuildUpdateRequest(ctx, plan, state)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		require.Len(t, req.InputsSchema, 1)
+		assert.Equal(t, "apiKey", req.InputsSchema[0]["key"])
+	})
+
+	t.Run("removing inputs_schema_json sends nil", func(t *testing.T) {
+		plan := HogFunctionResourceTFModel{
+			InputsSchemaJSON: types.StringNull(),
+		}
+		state := HogFunctionResourceTFModel{
+			InputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"}]`),
+		}
+
+		req, diags := ops.BuildUpdateRequest(ctx, plan, state)
+		require.False(t, diags.HasError(), "unexpected error: %v", diags)
+
+		assert.Nil(t, req.InputsSchema)
 	})
 }
 

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -182,7 +182,7 @@ func TestHogFunction_Import(t *testing.T) {
 				ResourceName:            "posthog_hog_function.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"hog", "inputs_json", "filters_json", "inputs_schema_json"},
+				ImportStateVerifyIgnore: []string{"hog", "inputs_json", "inputs_schema_json", "filters_json"},
 			},
 		},
 	})
@@ -354,10 +354,95 @@ func TestHogFunction_ImportWithSensitiveInputs(t *testing.T) {
 				ResourceName:            "posthog_hog_function.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"hog", "inputs_json", "sensitive_inputs_json", "filters_json"},
+				ImportStateVerifyIgnore: []string{"hog", "inputs_json", "sensitive_inputs_json", "inputs_schema_json", "filters_json"},
 			},
 		},
 	})
+}
+
+// TestHogFunction_InputsSchemaJSON tests creating a hog function with a custom
+// inputs_schema_json that extends the template's default schema.
+func TestHogFunction_InputsSchemaJSON(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHogFunctionDestroy,
+		Steps: []resource.TestStep{
+			// Create with inputs_schema_json
+			{
+				Config: testAccHogFunctionWithInputsSchema(rName, "secret-token-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "id"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_schema_json"),
+				),
+			},
+			// Update the sensitive input value
+			{
+				Config: testAccHogFunctionWithInputsSchema(rName, "secret-token-2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_schema_json"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHogFunctionWithInputsSchema(name, secret string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_hog_function" "test" {
+  name        = %q
+  description = "Test webhook with custom inputs schema"
+  type        = "destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  inputs_schema_json = jsonencode([
+    {
+      key      = "apiKey"
+      type     = "string"
+      label    = "API Key"
+      secret   = true
+      required = true
+    }
+  ])
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/webhook"
+      templating = "hog"
+    }
+    method = {
+      value      = "POST"
+      templating = "hog"
+    }
+  })
+
+  sensitive_inputs_json = jsonencode({
+    apiKey = {
+      value = "%s"
+    }
+  })
+
+  filters_json = jsonencode({
+    source = "events"
+    events = [{
+      id   = "$pageview"
+      name = "$pageview"
+      type = "events"
+    }]
+    filter_test_accounts = false
+  })
+}
+`, name, secret)
 }
 
 func testAccHogFunctionWithSensitiveInputs(name, url, secret string) string {

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -360,6 +360,42 @@ func TestHogFunction_ImportWithSensitiveInputs(t *testing.T) {
 	})
 }
 
+// TestHogFunction_InputsSchemaWithInputsJSON tests inputs_schema_json with
+// inputs_json only (no sensitive_inputs_json).
+func TestHogFunction_InputsSchemaWithInputsJSON(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHogFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHogFunctionInputsSchemaWithInputsJSON(rName, "us-east-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "id"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_schema_json"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_json"),
+					resource.TestCheckNoResourceAttr("posthog_hog_function.test", "sensitive_inputs_json"),
+				),
+			},
+			// Update the custom input value
+			{
+				Config: testAccHogFunctionInputsSchemaWithInputsJSON(rName, "eu-west-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_schema_json"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "inputs_json"),
+				),
+			},
+		},
+	})
+}
+
 // TestHogFunction_InputsSchemaJSON tests creating a hog function with a custom
 // inputs_schema_json that extends the template's default schema.
 func TestHogFunction_InputsSchemaJSON(t *testing.T) {
@@ -443,6 +479,53 @@ resource "posthog_hog_function" "test" {
   })
 }
 `, name, secret)
+}
+
+func testAccHogFunctionInputsSchemaWithInputsJSON(name, region string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_hog_function" "test" {
+  name        = %q
+  description = "Test webhook with custom inputs schema and inputs_json only"
+  type        = "destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  inputs_schema_json = jsonencode([
+    {
+      key      = "region"
+      type     = "string"
+      label    = "Region"
+      required = true
+    }
+  ])
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/webhook"
+      templating = "hog"
+    }
+    method = {
+      value      = "POST"
+      templating = "hog"
+    }
+    region = {
+      value = "%s"
+    }
+  })
+
+  filters_json = jsonencode({
+    source = "events"
+    events = [{
+      id   = "$pageview"
+      name = "$pageview"
+      type = "events"
+    }]
+    filter_test_accounts = false
+  })
+}
+`, name, region)
 }
 
 func testAccHogFunctionWithSensitiveInputs(name, url, secret string) string {


### PR DESCRIPTION
## Context

Addresses #60. 

When using `template-webhook` with custom Hog code that needs additional inputs (e.g. an API key), there is no way to extend the template's `inputs_schema` via Terraform. The PostHog API only persists inputs that match the schema — any extra inputs are silently discarded.

The workaround - embedding secrets in the `headers` input — makes them visible in the PostHog UI.

## Proposed approach

Add an `inputs_schema_json` attribute that sends the user's JSON array directly as `inputs_schema` in the API request. On read-back, the API response is filtered to only include entries whose `key` matches what the user defined, avoiding drift from template-provided schema entries.

Existing configs without `inputs_schema_json` work exactly as before.

### Example usage

```hcl
resource "posthog_hog_function" "example" {
  template_id = "template-webhook"
  hog         = file("custom.hog")

  inputs_schema_json = jsonencode([
    { key = "apiKey", type = "string", secret = true, required = true }
  ])

  inputs_json = jsonencode({
    url    = { value = "https://example.com/webhook", templating = "hog" }
    method = { value = "POST", templating = "hog" }
  })

  sensitive_inputs_json = jsonencode({
    apiKey = { value = var.api_key }
  })
}
```

## What changed

| File | Change |
|------|--------|
| `internal/resource/hog_function.go` | Added `InputsSchemaJSON` model field, schema attribute, parsing in `BuildCreateRequest`, key-based filtering in `MapResponseToModel` |
| `internal/resource/hog_function_test.go` | Added unit tests: schema flags, create (valid/invalid/null), response filtering (by key, null on import, empty response, multiple keys), update, invalid state, combined with inputs_json/sensitive_inputs_json |
| `testacc/hog_function_test.go` | Acceptance test for create + update cycle with custom schema entry; added `inputs_schema_json` to `ImportStateVerifyIgnore` |
| `docs/resources/hog_function.md` | Regenerated attribute docs |

## Things I am uncertain about

- Import behavior: on import, `inputs_schema_json` is left null since we can't distinguish user-added vs template-provided schema entries. Users would need to manually add `inputs_schema_json` to their config after import. This seems reasonable but open to suggestions.
- Whether the API merges or replaces the template's schema when `inputs_schema` is provided in the request. The implementation assumes replace semantics.

