### PR TITLE
fix: normalize feature flag filters state

### DIFF
--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -250,9 +250,9 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 
 	// Set filters if present
 	if len(resp.Filters) > 0 {
-		filtersJSON, err := json.Marshal(resp.Filters)
+		normalizedFilters, err := normalizeJSONForState(resp.Filters, model.Filters.ValueString())
 		if err == nil {
-			model.Filters = types.StringValue(string(filtersJSON))
+			model.Filters = types.StringValue(normalizedFilters)
 		}
 	} else {
 		model.Filters = types.StringNull()

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -1,0 +1,37 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/posthog/terraform-provider/internal/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureFlagMapResponseToModel_NormalizesServerOnlyFilterFields(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Filters: types.StringValue(`{"groups":[{"rollout_percentage":0}]}`),
+	}
+
+	resp := httpclient.FeatureFlag{
+		ID:  123,
+		Key: "classic_questionnaires_enabled",
+		Filters: map[string]interface{}{
+			"aggregation_group_type_index": nil,
+			"groups": []interface{}{
+				map[string]interface{}{
+					"aggregation_group_type_index": nil,
+					"rollout_percentage":           float64(0),
+				},
+			},
+		},
+	}
+
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, `{"groups":[{"rollout_percentage":0}]}`, model.Filters.ValueString())
+	assert.Equal(t, int64(0), model.RolloutPercentage.ValueInt64())
+}


### PR DESCRIPTION
## Summary

- normalize `posthog_feature_flag.filters` against the user-declared JSON before writing state
- add a regression test for server-only null fields such as `aggregation_group_type_index`
- prevent inconsistent-result-after-apply errors when PostHog augments feature flag filters in the API response

## Validation

- `go test ./...`
- targeted destroy/apply/re-plan of `posthog_feature_flag.classic_questionnaires_enabled` on a dedicated PostHog test project
- Sonar Quality Gate passed on the local Sonar stack