### PR TITLE
fix: normalize imported insight queries

### DIFF
--- a/internal/resource/insight.go
+++ b/internal/resource/insight.go
@@ -251,15 +251,51 @@ func normalizeQueryForState(apiQuery map[string]interface{}, userQueryJSON strin
 		return "", nil
 	}
 
+	cleanedQuery := stripInsightQueryServerFields(apiQuery)
+
+	userQueryJSON = strings.TrimSpace(userQueryJSON)
+	if userQueryJSON == "" {
+		return marshalJSON(cleanedQuery)
+	}
+
 	// Parse user's query to know which fields to keep
 	var userQuery map[string]interface{}
 	if err := json.Unmarshal([]byte(userQueryJSON), &userQuery); err != nil {
-		// If we can't parse user's query, fall back to returning API query as canonical JSON
-		return marshalJSON(apiQuery)
+		// If we can't parse user's query, fall back to returning a cleaned API query.
+		return marshalJSON(cleanedQuery)
 	}
 
-	filtered := filterToOnlyIncludeUserFields(userQuery, apiQuery)
+	filtered := filterToOnlyIncludeUserFields(userQuery, cleanedQuery)
 	return marshalJSON(filtered)
+}
+
+func stripInsightQueryServerFields(v interface{}) interface{} {
+	var serverComputedFields = map[string]struct{}{
+		"version":   {},
+		"result":    {},
+		"hogql":     {},
+		"is_cached": {},
+	}
+
+	switch val := v.(type) {
+	case map[string]interface{}:
+		cleaned := make(map[string]interface{}, len(val))
+		for key, value := range val {
+			if _, isServerField := serverComputedFields[key]; isServerField {
+				continue
+			}
+			cleaned[key] = stripInsightQueryServerFields(value)
+		}
+		return cleaned
+	case []interface{}:
+		cleaned := make([]interface{}, len(val))
+		for i, item := range val {
+			cleaned[i] = stripInsightQueryServerFields(item)
+		}
+		return cleaned
+	default:
+		return val
+	}
 }
 
 func marshalJSON(v interface{}) (string, error) {

--- a/internal/resource/insight_test.go
+++ b/internal/resource/insight_test.go
@@ -1,8 +1,11 @@
 package resource
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -192,10 +195,25 @@ func TestNormalizeQueryForState(t *testing.T) {
 		},
 		"falls back on invalid user JSON": {
 			apiQuery: map[string]interface{}{
-				"kind": "test",
+				"kind":    "test",
+				"version": float64(2),
 			},
 			userQueryJSON: `invalid json`,
 			expected:      `{"kind":"test"}`,
+		},
+		"strips server fields when user query is unavailable": {
+			apiQuery: map[string]interface{}{
+				"kind":      "DataVisualizationNode",
+				"result":    []interface{}{1, 2, 3},
+				"hogql":     "SELECT 1",
+				"is_cached": true,
+				"source": map[string]interface{}{
+					"kind":    "TrendsQuery",
+					"version": float64(2),
+				},
+			},
+			userQueryJSON: "",
+			expected:      `{"kind":"DataVisualizationNode","source":{"kind":"TrendsQuery"}}`,
 		},
 	}
 
@@ -206,4 +224,29 @@ func TestNormalizeQueryForState(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestInsightMapResponseToModel_StripsServerQueryFieldsWithoutUserConfig(t *testing.T) {
+	ops := InsightOps{}
+	model := InsightResourceTFModel{
+		QueryJSON: types.StringNull(),
+	}
+
+	resp := httpclient.Insight{
+		ID: 123,
+		Query: map[string]interface{}{
+			"kind":      "DataVisualizationNode",
+			"result":    []interface{}{1, 2, 3},
+			"hogql":     "SELECT 1",
+			"is_cached": true,
+			"source": map[string]interface{}{
+				"kind":    "TrendsQuery",
+				"version": float64(2),
+			},
+		},
+	}
+
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, `{"kind":"DataVisualizationNode","source":{"kind":"TrendsQuery"}}`, model.QueryJSON.ValueString())
 }

--- a/testacc/insight_test.go
+++ b/testacc/insight_test.go
@@ -300,7 +300,7 @@ func TestInsight_Import(t *testing.T) {
 				ResourceName:            "posthog_insight.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"query_json", "create_in_folder"},
+				ImportStateVerifyIgnore: []string{"create_in_folder"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- strip server-computed fields from `posthog_insight.query_json` before normalizing it for state
- keep imported insight state aligned with the configured query shape so the first post-import plan is clean
- tighten the import tests so `query_json` is verified instead of ignored

## Validation

- `go test ./...`
- real `terraform state rm` + `terraform import` + `terraform plan -target=posthog_insight.identified_active_users_28d` on the dedicated PostHog test project -> `No changes`
- Sonar Quality Gate passed on the local Sonar stack