### PR TITLE
feat: expose dashboard layout show_description

### DIFF
--- a/docs/resources/dashboard_layout.md
+++ b/docs/resources/dashboard_layout.md
@@ -57,13 +57,15 @@ resource "posthog_dashboard_layout" "engineering" {
     },
     # Insight tiles positioned below the header
     {
-      insight_id   = posthog_insight.pageviews.id
-      layouts_json = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 4 } })
-      color        = "blue"
+      insight_id       = posthog_insight.pageviews.id
+      layouts_json     = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 4 } })
+      color            = "blue"
+      show_description = false
     },
     {
-      insight_id   = posthog_insight.signups.id
-      layouts_json = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 4 } })
+      insight_id       = posthog_insight.signups.id
+      layouts_json     = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 4 } })
+      show_description = false
     },
   ]
 
@@ -123,6 +125,7 @@ Optional:
 - `color` (String) Background color of the tile. Valid values are defined by the PostHog API; see [InsightColor in types.ts](https://github.com/PostHog/posthog/blob/master/frontend/src/types.ts#L2154) for the current list.
 - `insight_id` (Number) ID of the insight to display. Exactly one of insight_id or text_body must be set.
 - `layouts_json` (String) JSON object with breakpoint keys `sm` and/or `xs`, each containing position properties: `x`, `y`, `w`, `h` (required), and optionally `minW`, `minH` (e.g. `{"sm":{"x":0,"y":0,"w":6,"h":5},"xs":{"x":0,"y":0,"w":1,"h":5}}`). Semantic JSON equality is used to suppress phantom diffs.
+- `show_description` (Boolean) Whether to show the insight description on the tile. Omit the field to clear it back to the PostHog API default (`null`).
 - `text_body` (String) Markdown body for a text tile (max 4000 characters). Exactly one of insight_id or text_body must be set.
 
 Read-Only:

--- a/examples/dashboard-layouts/main.tf
+++ b/examples/dashboard-layouts/main.tf
@@ -5,9 +5,10 @@
 # 2. Create insights to display on the dashboard
 # 3. Arrange tiles (insights + text) with precise grid positions
 # 4. Optionally: add color to highlight specific tiles
-# 5. Optionally: update a text tile body in place
-# 6. Optionally: add a new tile
-# 7. Optionally: remove a tile and reposition
+# 5. Optionally: hide an insight description at tile level
+# 6. Optionally: update a text tile body in place
+# 7. Optionally: add a new tile
+# 8. Optionally: remove a tile and reposition
 
 # =============================================================================
 # Step 1: Create the dashboard
@@ -75,12 +76,14 @@ resource "posthog_dashboard_layout" "demo" {
       layouts_json = jsonencode({ sm = { x = 0, y = 0, w = 12, h = 1 } })
     },
     {
-      insight_id   = posthog_insight.pageviews.id
-      layouts_json = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 5 } })
+      insight_id       = posthog_insight.pageviews.id
+      layouts_json     = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 5 } })
+      show_description = false
     },
     {
-      insight_id   = posthog_insight.sessions.id
-      layouts_json = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 5 } })
+      insight_id       = posthog_insight.sessions.id
+      layouts_json     = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 5 } })
+      show_description = false
     },
   ]
 
@@ -116,7 +119,38 @@ resource "posthog_dashboard_layout" "demo" {
 # }
 
 # =============================================================================
-# Step 5 (Optional): Update text tile body in place
+# Step 5 (Optional): Hide an insight description
+#
+# Omit the field to clear it back to the PostHog default (`null`).
+# =============================================================================
+
+# Uncomment to use (comment out Steps 3-4 first):
+
+# resource "posthog_dashboard_layout" "demo" {
+#   dashboard_id = posthog_dashboard.demo.id
+#
+#   tiles = [
+#     {
+#       text_body    = "## Production Metrics"
+#       layouts_json = jsonencode({ sm = { x = 0, y = 0, w = 12, h = 1 } })
+#     },
+#     {
+#       insight_id       = posthog_insight.pageviews.id
+#       show_description = false
+#       layouts_json     = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 5 } })
+#     },
+#     {
+#       insight_id       = posthog_insight.sessions.id
+#       show_description = false
+#       layouts_json     = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 5 } })
+#     },
+#   ]
+#
+#   depends_on = [posthog_insight.pageviews, posthog_insight.sessions]
+# }
+
+# =============================================================================
+# Step 6 (Optional): Update text tile body in place
 #
 # Changing a text tile's body updates the existing tile (matched by position).
 # The tile_id stays stable — no destroy/recreate.
@@ -146,7 +180,7 @@ resource "posthog_dashboard_layout" "demo" {
 # }
 
 # =============================================================================
-# Step 6 (Optional): Add a footer text tile
+# Step 7 (Optional): Add a footer text tile
 #
 # Adding a tile increases the count. Existing tiles keep their tile_ids.
 # =============================================================================
@@ -179,7 +213,7 @@ resource "posthog_dashboard_layout" "demo" {
 # }
 
 # =============================================================================
-# Step 7 (Optional): Remove an insight and reposition
+# Step 8 (Optional): Remove an insight and reposition
 #
 # Removing a tile from the list clears its layout (insight tiles) or
 # soft-deletes it (text tiles). Remaining tiles can be repositioned freely.

--- a/examples/resources/posthog_dashboard_layout/resource.tf
+++ b/examples/resources/posthog_dashboard_layout/resource.tf
@@ -42,13 +42,15 @@ resource "posthog_dashboard_layout" "engineering" {
     },
     # Insight tiles positioned below the header
     {
-      insight_id   = posthog_insight.pageviews.id
-      layouts_json = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 4 } })
-      color        = "blue"
+      insight_id       = posthog_insight.pageviews.id
+      layouts_json     = jsonencode({ sm = { x = 0, y = 1, w = 6, h = 4 } })
+      color            = "blue"
+      show_description = false
     },
     {
-      insight_id   = posthog_insight.signups.id
-      layouts_json = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 4 } })
+      insight_id       = posthog_insight.signups.id
+      layouts_json     = jsonencode({ sm = { x = 6, y = 1, w = 6, h = 4 } })
+      show_description = false
     },
   ]
 

--- a/internal/httpclient/dashboard_layout.go
+++ b/internal/httpclient/dashboard_layout.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -15,12 +16,13 @@ type DashboardTileText struct {
 }
 
 type DashboardTile struct {
-	ID      int64                  `json:"id"`
-	Insight *DashboardTileInsight  `json:"insight,omitempty"`
-	Text    *DashboardTileText     `json:"text,omitempty"`
-	Layouts map[string]interface{} `json:"layouts"`
-	Color   *string                `json:"color,omitempty"`
-	Deleted *bool                  `json:"deleted,omitempty"`
+	ID              int64                  `json:"id"`
+	Insight         *DashboardTileInsight  `json:"insight,omitempty"`
+	Text            *DashboardTileText     `json:"text,omitempty"`
+	Layouts         map[string]interface{} `json:"layouts"`
+	Color           *string                `json:"color,omitempty"`
+	ShowDescription *bool                  `json:"show_description,omitempty"`
+	Deleted         *bool                  `json:"deleted,omitempty"`
 }
 
 type DashboardLayoutResponse struct {
@@ -33,15 +35,52 @@ type DashboardTileTextPatch struct {
 }
 
 type DashboardTilePatchItem struct {
-	ID      int64                   `json:"id,omitempty"`
-	Deleted *bool                   `json:"deleted,omitempty"`
-	Color   *string                 `json:"color,omitempty"`
-	Layouts *map[string]interface{} `json:"layouts,omitempty"`
-	Text    *DashboardTileTextPatch `json:"text,omitempty"`
+	ID                   int64                   `json:"id,omitempty"`
+	Deleted              *bool                   `json:"deleted,omitempty"`
+	Color                *string                 `json:"color,omitempty"`
+	Layouts              *map[string]interface{} `json:"layouts,omitempty"`
+	Text                 *DashboardTileTextPatch `json:"text,omitempty"`
+	ShowDescription      *bool                   `json:"-"`
+	ClearShowDescription bool                    `json:"-"`
 }
 
 type DashboardLayoutPatchRequest struct {
 	Tiles []DashboardTilePatchItem `json:"tiles"`
+}
+
+func (i DashboardTilePatchItem) MarshalJSON() ([]byte, error) {
+	type dashboardTilePatchItemAlias struct {
+		ID              int64                   `json:"id,omitempty"`
+		Deleted         *bool                   `json:"deleted,omitempty"`
+		Color           *string                 `json:"color,omitempty"`
+		Layouts         *map[string]interface{} `json:"layouts,omitempty"`
+		Text            *DashboardTileTextPatch `json:"text,omitempty"`
+		ShowDescription *bool                   `json:"show_description,omitempty"`
+	}
+
+	payload := dashboardTilePatchItemAlias{
+		ID:              i.ID,
+		Deleted:         i.Deleted,
+		Color:           i.Color,
+		Layouts:         i.Layouts,
+		Text:            i.Text,
+		ShowDescription: i.ShowDescription,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !i.ClearShowDescription {
+		return data, nil
+	}
+
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, err
+	}
+	object["show_description"] = nil
+	return json.Marshal(object)
 }
 
 // GetDashboardLayout fetches the tile layout for a specific dashboard.

--- a/internal/httpclient/dashboard_layout_test.go
+++ b/internal/httpclient/dashboard_layout_test.go
@@ -1,0 +1,34 @@
+package httpclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardTilePatchItemMarshalJSON(t *testing.T) {
+	t.Run("encodes boolean show_description when configured", func(t *testing.T) {
+		value := false
+		item := DashboardTilePatchItem{
+			ID:              10,
+			ShowDescription: &value,
+		}
+
+		data, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"show_description":false}`, string(data))
+	})
+
+	t.Run("encodes null show_description when clearing", func(t *testing.T) {
+		item := DashboardTilePatchItem{
+			ID:                   10,
+			ClearShowDescription: true,
+		}
+
+		data, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"show_description":null}`, string(data))
+	})
+}

--- a/internal/resource/dashboard_layout.go
+++ b/internal/resource/dashboard_layout.go
@@ -26,11 +26,12 @@ import (
 )
 
 type TileTFModel struct {
-	TileID      types.Int64          `tfsdk:"tile_id"`
-	InsightID   types.Int64          `tfsdk:"insight_id"`
-	TextBody    types.String         `tfsdk:"text_body"`
-	Color       types.String         `tfsdk:"color"`
-	LayoutsJSON jsontypes.Normalized `tfsdk:"layouts_json"`
+	TileID          types.Int64          `tfsdk:"tile_id"`
+	InsightID       types.Int64          `tfsdk:"insight_id"`
+	TextBody        types.String         `tfsdk:"text_body"`
+	Color           types.String         `tfsdk:"color"`
+	ShowDescription types.Bool           `tfsdk:"show_description"`
+	LayoutsJSON     jsontypes.Normalized `tfsdk:"layouts_json"`
 }
 
 func (t TileTFModel) IsInsightTile() bool {
@@ -50,11 +51,12 @@ type DashboardLayoutTFModel struct {
 
 var tilesObjectType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
-		"tile_id":      types.Int64Type,
-		"insight_id":   types.Int64Type,
-		"text_body":    types.StringType,
-		"color":        types.StringType,
-		"layouts_json": jsontypes.NormalizedType{},
+		"tile_id":          types.Int64Type,
+		"insight_id":       types.Int64Type,
+		"text_body":        types.StringType,
+		"color":            types.StringType,
+		"show_description": types.BoolType,
+		"layouts_json":     jsontypes.NormalizedType{},
 	},
 }
 
@@ -64,6 +66,12 @@ type DashboardLayoutOps struct {
 	// multiple resources of the same type concurrently; each dashboard ID is
 	// written by one goroutine and consumed (LoadAndDelete) by the same one.
 	planTilesByDashboard sync.Map // map[int64][]TileTFModel
+}
+
+type stateTileLookups struct {
+	insightToTileID  map[int64]int64
+	bodyToTileIDs    map[string][]int64
+	tileIDToStateIdx map[int64]int
 }
 
 func NewDashboardLayout() resource.Resource {
@@ -127,6 +135,10 @@ func (o *DashboardLayoutOps) Schema() schema.Schema {
 							Validators: []validator.String{
 								stringvalidator.LengthAtLeast(1),
 							},
+						},
+						"show_description": schema.BoolAttribute{
+							Optional:            true,
+							MarkdownDescription: "Whether to show the insight description on the tile. Omit the field to clear it back to the PostHog API default (`null`).",
 						},
 						"layouts_json": schema.StringAttribute{
 							Optional:            true,
@@ -193,20 +205,7 @@ func (o *DashboardLayoutOps) ModifyResourcePlan(ctx context.Context, req resourc
 // the tile_id from state into the plan. It returns a new slice with resolved tile_ids,
 // or nil if no tile_id was resolved.
 func resolveTileIDs(planTiles, stateTiles []TileTFModel) []TileTFModel {
-	// Build state lookups.
-	insightToTileID := make(map[int64]int64, len(stateTiles))
-	bodyToTileIDs := make(map[string][]int64, len(stateTiles))
-	tileIDToStateIdx := make(map[int64]int, len(stateTiles))
-	for si, st := range stateTiles {
-		tid := st.TileID.ValueInt64()
-		tileIDToStateIdx[tid] = si
-		if st.IsInsightTile() {
-			insightToTileID[st.InsightID.ValueInt64()] = tid
-		} else if st.IsTextTile() {
-			body := st.TextBody.ValueString()
-			bodyToTileIDs[body] = append(bodyToTileIDs[body], tid)
-		}
-	}
+	lookups := buildStateTileLookups(stateTiles)
 
 	result := make([]TileTFModel, len(planTiles))
 	copy(result, planTiles)
@@ -218,32 +217,16 @@ func resolveTileIDs(planTiles, stateTiles []TileTFModel) []TileTFModel {
 		if !pt.TileID.IsUnknown() {
 			continue
 		}
-		var tileID int64
-		found := false
-		if pt.IsInsightTile() {
-			tileID, found = insightToTileID[pt.InsightID.ValueInt64()]
-		} else if pt.IsTextTile() {
-			body := pt.TextBody.ValueString()
-			if ids := bodyToTileIDs[body]; len(ids) > 0 {
-				tileID = ids[0]
-				bodyToTileIDs[body] = ids[1:]
-				found = true
-			}
-		}
+		tileID, found := resolveTileIDFromState(pt, &lookups)
 		if found && tileID != 0 {
 			result[i].TileID = types.Int64Value(tileID)
 			modified = true
-			matchedStateIdx[tileIDToStateIdx[tileID]] = true
+			matchedStateIdx[lookups.tileIDToStateIdx[tileID]] = true
 		}
 	}
 
 	// Pass 2: Positional fallback for remaining unmatched text tiles.
-	var unmatchedStateTileIDs []int64
-	for si, st := range stateTiles {
-		if !matchedStateIdx[si] && st.IsTextTile() {
-			unmatchedStateTileIDs = append(unmatchedStateTileIDs, st.TileID.ValueInt64())
-		}
-	}
+	unmatchedStateTileIDs := collectUnmatchedStateTextTileIDs(stateTiles, matchedStateIdx)
 	positionalIdx := 0
 	for i := range result {
 		if !result[i].TileID.IsUnknown() || !result[i].IsTextTile() {
@@ -264,6 +247,61 @@ func resolveTileIDs(planTiles, stateTiles []TileTFModel) []TileTFModel {
 		return nil
 	}
 	return result
+}
+
+func buildStateTileLookups(stateTiles []TileTFModel) stateTileLookups {
+	lookups := stateTileLookups{
+		insightToTileID:  make(map[int64]int64, len(stateTiles)),
+		bodyToTileIDs:    make(map[string][]int64, len(stateTiles)),
+		tileIDToStateIdx: make(map[int64]int, len(stateTiles)),
+	}
+
+	for si, st := range stateTiles {
+		tid := st.TileID.ValueInt64()
+		lookups.tileIDToStateIdx[tid] = si
+		if st.IsInsightTile() {
+			lookups.insightToTileID[st.InsightID.ValueInt64()] = tid
+			continue
+		}
+		if st.IsTextTile() {
+			body := st.TextBody.ValueString()
+			lookups.bodyToTileIDs[body] = append(lookups.bodyToTileIDs[body], tid)
+		}
+	}
+
+	return lookups
+}
+
+func resolveTileIDFromState(tile TileTFModel, lookups *stateTileLookups) (int64, bool) {
+	if tile.IsInsightTile() {
+		tileID, found := lookups.insightToTileID[tile.InsightID.ValueInt64()]
+		return tileID, found
+	}
+	if tile.IsTextTile() {
+		return lookups.takeNextTextTileID(tile.TextBody.ValueString())
+	}
+	return 0, false
+}
+
+func (l *stateTileLookups) takeNextTextTileID(body string) (int64, bool) {
+	ids := l.bodyToTileIDs[body]
+	if len(ids) == 0 {
+		return 0, false
+	}
+	tileID := ids[0]
+	l.bodyToTileIDs[body] = ids[1:]
+	return tileID, true
+}
+
+func collectUnmatchedStateTextTileIDs(stateTiles []TileTFModel, matchedStateIdx map[int]bool) []int64 {
+	var unmatchedStateTileIDs []int64
+	for si, st := range stateTiles {
+		if matchedStateIdx[si] || !st.IsTextTile() {
+			continue
+		}
+		unmatchedStateTileIDs = append(unmatchedStateTileIDs, st.TileID.ValueInt64())
+	}
+	return unmatchedStateTileIDs
 }
 
 func (o *DashboardLayoutOps) BuildCreateRequest(_ context.Context, _ DashboardLayoutTFModel) (httpclient.DashboardLayoutPatchRequest, diag.Diagnostics) {
@@ -442,33 +480,54 @@ func matchDeclaredTilesToAPI(declaredTiles []TileTFModel, apiTiles []httpclient.
 	matches := make([]*httpclient.DashboardTile, len(declaredTiles))
 
 	for i, declared := range declaredTiles {
-		if declared.IsInsightTile() {
-			if idx, ok := insightIdxMap[declared.InsightID.ValueInt64()]; ok {
-				matchedIDs[apiTiles[idx].ID] = true
-				matches[i] = &apiTiles[idx]
-			}
-		} else if declared.IsTextTile() {
-			tileID := declared.TileID.ValueInt64()
-			if tileID != 0 {
-				if idx, ok := textIdxMap[tileID]; ok {
-					matchedIDs[apiTiles[idx].ID] = true
-					matches[i] = &apiTiles[idx]
-					continue
-				}
-			}
-			// Fall back to body matching. tile_id is Computed and will be
-			// unknown/zero during create, so body is the only stable identity.
-			for j := range apiTiles {
-				if apiTiles[j].Text != nil && !matchedIDs[apiTiles[j].ID] && apiTiles[j].Text.Body == declared.TextBody.ValueString() {
-					matchedIDs[apiTiles[j].ID] = true
-					matches[i] = &apiTiles[j]
-					break
-				}
-			}
+		match := findDeclaredTileMatch(declared, apiTiles, insightIdxMap, textIdxMap, matchedIDs)
+		if match != nil {
+			matchedIDs[match.ID] = true
+			matches[i] = match
 		}
 	}
 
 	return matches, matchedIDs
+}
+
+func findDeclaredTileMatch(declared TileTFModel, apiTiles []httpclient.DashboardTile, insightIdxMap, textIdxMap map[int64]int, matchedIDs map[int64]bool) *httpclient.DashboardTile {
+	if declared.IsInsightTile() {
+		return matchInsightTileByInsightID(declared, apiTiles, insightIdxMap)
+	}
+	if declared.IsTextTile() {
+		return matchTextTileByTileIDOrBody(declared, apiTiles, textIdxMap, matchedIDs)
+	}
+	return nil
+}
+
+func matchInsightTileByInsightID(declared TileTFModel, apiTiles []httpclient.DashboardTile, insightIdxMap map[int64]int) *httpclient.DashboardTile {
+	idx, ok := insightIdxMap[declared.InsightID.ValueInt64()]
+	if !ok {
+		return nil
+	}
+	return &apiTiles[idx]
+}
+
+func matchTextTileByTileIDOrBody(declared TileTFModel, apiTiles []httpclient.DashboardTile, textIdxMap map[int64]int, matchedIDs map[int64]bool) *httpclient.DashboardTile {
+	tileID := declared.TileID.ValueInt64()
+	if tileID != 0 {
+		if idx, ok := textIdxMap[tileID]; ok {
+			return &apiTiles[idx]
+		}
+	}
+	return matchTextTileByBody(declared.TextBody.ValueString(), apiTiles, matchedIDs)
+}
+
+func matchTextTileByBody(body string, apiTiles []httpclient.DashboardTile, matchedIDs map[int64]bool) *httpclient.DashboardTile {
+	for i := range apiTiles {
+		if apiTiles[i].Text == nil || matchedIDs[apiTiles[i].ID] {
+			continue
+		}
+		if apiTiles[i].Text.Body == body {
+			return &apiTiles[i]
+		}
+	}
+	return nil
 }
 
 // buildLayoutPatch builds the set of tile patch items for a PATCH request.
@@ -567,6 +626,16 @@ func buildTilePatchItem(ctx context.Context, tileID int64, declared TileTFModel)
 		item.Color = &c
 	}
 
+	// Omitted config is authoritative: reset to the API default by sending null.
+	if !declared.ShowDescription.IsUnknown() {
+		if declared.ShowDescription.IsNull() {
+			item.ClearShowDescription = true
+		} else {
+			showDescription := declared.ShowDescription.ValueBool()
+			item.ShowDescription = &showDescription
+		}
+	}
+
 	if declared.IsTextTile() {
 		item.Text = &httpclient.DashboardTileTextPatch{Body: declared.TextBody.ValueString()}
 	}
@@ -599,6 +668,8 @@ func apiTileToTFModel(t httpclient.DashboardTile) TileTFModel {
 	} else {
 		tile.Color = types.StringNull()
 	}
+
+	tile.ShowDescription = core.PtrToBool(t.ShowDescription)
 
 	if len(t.Layouts) > 0 {
 		bytes, err := json.Marshal(t.Layouts)

--- a/internal/resource/dashboard_layout_test.go
+++ b/internal/resource/dashboard_layout_test.go
@@ -196,6 +196,64 @@ func TestBuildLayoutPatch(t *testing.T) {
 				assert.Equal(t, "", *items[0].Color, "null config color should send empty string to clear")
 			},
 		},
+		"show_description false is sent in patch": {
+			declaredTiles: []TileTFModel{
+				{
+					TileID:          types.Int64Null(),
+					InsightID:       types.Int64Value(42),
+					TextBody:        types.StringNull(),
+					Color:           types.StringNull(),
+					ShowDescription: types.BoolValue(false),
+					LayoutsJSON:     jsontypes.NewNormalizedNull(),
+				},
+			},
+			apiTiles: []httpclient.DashboardTile{
+				{
+					ID:      10,
+					Insight: &httpclient.DashboardTileInsight{ID: 42},
+					Layouts: map[string]interface{}{},
+				},
+			},
+			wantPatchIDs:   []int64{10},
+			wantMissingIDs: nil,
+			wantPatchCount: 1,
+			checkPatchItem: func(t *testing.T, items []httpclient.DashboardTilePatchItem) {
+				t.Helper()
+				require.Len(t, items, 1)
+				require.NotNil(t, items[0].ShowDescription)
+				assert.False(t, *items[0].ShowDescription)
+				assert.False(t, items[0].ClearShowDescription)
+			},
+		},
+		"null show_description clears to api default": {
+			declaredTiles: []TileTFModel{
+				{
+					TileID:          types.Int64Null(),
+					InsightID:       types.Int64Value(42),
+					TextBody:        types.StringNull(),
+					Color:           types.StringNull(),
+					ShowDescription: types.BoolNull(),
+					LayoutsJSON:     jsontypes.NewNormalizedNull(),
+				},
+			},
+			apiTiles: []httpclient.DashboardTile{
+				{
+					ID:              10,
+					Insight:         &httpclient.DashboardTileInsight{ID: 42},
+					Layouts:         map[string]interface{}{},
+					ShowDescription: boolPtr(true),
+				},
+			},
+			wantPatchIDs:   []int64{10},
+			wantMissingIDs: nil,
+			wantPatchCount: 1,
+			checkPatchItem: func(t *testing.T, items []httpclient.DashboardTilePatchItem) {
+				t.Helper()
+				require.Len(t, items, 1)
+				assert.Nil(t, items[0].ShowDescription)
+				assert.True(t, items[0].ClearShowDescription)
+			},
+		},
 		"unmanaged text tile soft-deleted": {
 			declaredTiles: []TileTFModel{},
 			apiTiles: []httpclient.DashboardTile{
@@ -471,6 +529,31 @@ func TestBuildDeletePatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDashboardTilePatchItemMarshalJSON_ShowDescription(t *testing.T) {
+	t.Run("encodes boolean show_description when configured", func(t *testing.T) {
+		value := false
+		item := httpclient.DashboardTilePatchItem{
+			ID:              10,
+			ShowDescription: &value,
+		}
+
+		data, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"show_description":false}`, string(data))
+	})
+
+	t.Run("encodes null show_description when clearing", func(t *testing.T) {
+		item := httpclient.DashboardTilePatchItem{
+			ID:                   10,
+			ClearShowDescription: true,
+		}
+
+		data, err := json.Marshal(item)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":10,"show_description":null}`, string(data))
+	})
 }
 
 func TestMapTilesToState(t *testing.T) {
@@ -828,6 +911,31 @@ func TestApiTileToTFModel(t *testing.T) {
 			checkResult: func(t *testing.T, result TileTFModel) {
 				t.Helper()
 				assert.True(t, result.Color.IsNull(), "Color should be null when API color is nil")
+			},
+		},
+		"show description false": {
+			apiTile: httpclient.DashboardTile{
+				ID:              8,
+				Insight:         &httpclient.DashboardTileInsight{ID: 8},
+				Layouts:         map[string]interface{}{},
+				ShowDescription: boolPtr(false),
+			},
+			checkResult: func(t *testing.T, result TileTFModel) {
+				t.Helper()
+				assert.False(t, result.ShowDescription.IsNull(), "ShowDescription should be set when API returns false")
+				assert.False(t, result.ShowDescription.ValueBool())
+			},
+		},
+		"nil show description": {
+			apiTile: httpclient.DashboardTile{
+				ID:              9,
+				Insight:         &httpclient.DashboardTileInsight{ID: 9},
+				Layouts:         map[string]interface{}{},
+				ShowDescription: nil,
+			},
+			checkResult: func(t *testing.T, result TileTFModel) {
+				t.Helper()
+				assert.True(t, result.ShowDescription.IsNull(), "ShowDescription should be null when API omits it")
 			},
 		},
 		"empty color string": {
@@ -1376,6 +1484,10 @@ func TestResolveTileIDs(t *testing.T) {
 // strPtr is a helper to create a pointer to a string literal.
 func strPtr(s string) *string {
 	return &s
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }
 
 // buildModifyPlanReqResp constructs a ModifyPlanRequest and ModifyPlanResponse

--- a/testacc/dashboard_layout_test.go
+++ b/testacc/dashboard_layout_test.go
@@ -12,13 +12,24 @@ import (
 	"github.com/posthog/terraform-provider/internal/httpclient"
 )
 
+const (
+	dashboardLayoutRandomPrefix        = "tf-acc-test"
+	dashboardLayoutResourceName        = "posthog_dashboard_layout.test"
+	dashboardResourceName              = "posthog_dashboard.test"
+	dashboardLayoutTilesCountAttr      = "tiles.#"
+	dashboardLayoutFirstTileIDAttr     = "tiles.0.tile_id"
+	dashboardLayoutFirstTileColorAttr  = "tiles.0.color"
+	dashboardLayoutShowDescriptionAttr = "tiles.0.show_description"
+	dashboardLayoutResourceNotFoundFmt = "resource not found: %s"
+)
+
 // TestDashboardLayout_CRUD tests the full create/update/destroy lifecycle of a
 // posthog_dashboard_layout resource: create with a single insight tile, add a
 // text tile, update the insight tile position, change the text tile body
 // (in-place update via positional fallback), then implicitly destroy.
 func TestDashboardLayout_CRUD(t *testing.T) {
 	skipIfNotAcceptance(t)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -27,39 +38,39 @@ func TestDashboardLayout_CRUD(t *testing.T) {
 			{
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("posthog_dashboard_layout.test", "id"),
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "1"),
-					resource.TestCheckResourceAttrSet("posthog_dashboard_layout.test", "tiles.0.tile_id"),
-					resource.TestCheckResourceAttrPair("posthog_dashboard_layout.test", "dashboard_id", "posthog_dashboard.test", "id"),
+					resource.TestCheckResourceAttrSet(dashboardLayoutResourceName, "id"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "1"),
+					resource.TestCheckResourceAttrSet(dashboardLayoutResourceName, dashboardLayoutFirstTileIDAttr),
+					resource.TestCheckResourceAttrPair(dashboardLayoutResourceName, "dashboard_id", dashboardResourceName, "id"),
 				),
 			},
 			// Step 2: Update — add a text tile (now 2 tiles total)
 			{
 				Config: testAccDashboardLayoutInsightAndText(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "2"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "2"),
 				),
 			},
 			// Step 3: Update — change layout position of the insight tile
 			{
 				Config: testAccDashboardLayoutUpdatedPosition(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "2"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "2"),
 				),
 			},
 			// Step 4: Update — change text tile body (should update in place, not orphan)
 			{
 				Config: testAccDashboardLayoutChangedTextBody(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "2"),
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.0.text_body", "## Updated Header"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "2"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, "tiles.0.text_body", "## Updated Header"),
 				),
 			},
 			// Step 5: Update — remove text tile, back to insight-only
 			{
 				Config: testAccDashboardLayoutSingleInsightShifted(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "1"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "1"),
 				),
 			},
 			// Implicit destroy at end of resource.Test
@@ -71,7 +82,7 @@ func TestDashboardLayout_CRUD(t *testing.T) {
 // and that the resulting state matches the configuration.
 func TestDashboardLayout_Import(t *testing.T) {
 	skipIfNotAcceptance(t)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -80,12 +91,12 @@ func TestDashboardLayout_Import(t *testing.T) {
 			{
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("posthog_dashboard_layout.test", "id"),
+					resource.TestCheckResourceAttrSet(dashboardLayoutResourceName, "id"),
 				),
 			},
 			// Step 2: Import
 			{
-				ResourceName:      "posthog_dashboard_layout.test",
+				ResourceName:      dashboardLayoutResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// tiles is ignored because import returns API-order tiles, which may differ
@@ -96,12 +107,47 @@ func TestDashboardLayout_Import(t *testing.T) {
 	})
 }
 
+func TestDashboardLayout_ShowDescription(t *testing.T) {
+	skipIfNotAcceptance(t)
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDashboardLayoutInsightWithShowDescription(rName, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutShowDescriptionAttr, "false"),
+				),
+			},
+			{
+				ResourceName:            dashboardLayoutResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{dashboardLayoutFirstTileIDAttr},
+			},
+			{
+				Config: testAccDashboardLayoutInsightWithShowDescription(rName, "true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutShowDescriptionAttr, "true"),
+				),
+			},
+			{
+				Config: testAccDashboardLayoutSingleInsight(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(dashboardLayoutResourceName, dashboardLayoutShowDescriptionAttr),
+				),
+			},
+		},
+	})
+}
+
 // TestDashboardLayout_AuthoritativeTextTileDelete verifies that text tiles added
 // outside of Terraform are soft-deleted by apply. The resource is fully authoritative:
 // unmanaged text tiles are deleted, unmanaged insight tiles have layouts cleared.
 func TestDashboardLayout_AuthoritativeTextTileDelete(t *testing.T) {
 	skipIfNotAcceptance(t)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
 
 	host := os.Getenv("POSTHOG_HOST")
 	apiKey := os.Getenv("POSTHOG_API_KEY")
@@ -118,12 +164,12 @@ func TestDashboardLayout_AuthoritativeTextTileDelete(t *testing.T) {
 			{
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "1"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "1"),
 					// Capture dashboard ID for API calls
 					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources["posthog_dashboard.test"]
+						rs, ok := s.RootModule().Resources[dashboardResourceName]
 						if !ok {
-							return fmt.Errorf("resource not found: posthog_dashboard.test")
+							return fmt.Errorf(dashboardLayoutResourceNotFoundFmt, dashboardResourceName)
 						}
 						dashboardID = rs.Primary.ID
 						return nil
@@ -155,7 +201,7 @@ func TestDashboardLayout_AuthoritativeTextTileDelete(t *testing.T) {
 				Config: testAccDashboardLayoutSingleInsightShifted(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Terraform state should still show only 1 managed tile
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.#", "1"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutTilesCountAttr, "1"),
 					// Verify the external text tile was soft-deleted by authoritative enforcement
 					func(s *terraform.State) error {
 						resp, _, err := (&client).GetDashboardLayout(
@@ -369,7 +415,7 @@ resource "posthog_dashboard_layout" "test" {
 // dashboard layout tile: set, change, remove, re-add.
 func TestDashboardLayout_Color(t *testing.T) {
 	skipIfNotAcceptance(t)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -378,42 +424,40 @@ func TestDashboardLayout_Color(t *testing.T) {
 			{
 				Config: testAccDashboardLayoutInsightWithColor(rName, "blue"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.0.color", "blue"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr, "blue"),
 				),
 			},
 			// Step 2: Change color to "green"
 			{
 				Config: testAccDashboardLayoutInsightWithColor(rName, "green"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.0.color", "green"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr, "green"),
 				),
 			},
 			// Step 3: Remove color (omit from config)
 			{
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("posthog_dashboard_layout.test", "tiles.0.color"),
+					resource.TestCheckNoResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr),
 				),
 			},
 			// Step 4: Re-add color "purple"
 			{
 				Config: testAccDashboardLayoutInsightWithColor(rName, "purple"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("posthog_dashboard_layout.test", "tiles.0.color", "purple"),
+					resource.TestCheckResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr, "purple"),
 				),
 			},
 		},
 	})
 }
 
-
-
 // TestDashboardLayout_ColorDriftClearedByApply verifies that a color set via the
 // API (outside Terraform) is detected as drift and cleared on the next apply when
 // the config does not declare a color.
 func TestDashboardLayout_ColorDriftClearedByApply(t *testing.T) {
 	skipIfNotAcceptance(t)
-	rName := acctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(dashboardLayoutRandomPrefix)
 
 	host := os.Getenv("POSTHOG_HOST")
 	apiKey := os.Getenv("POSTHOG_API_KEY")
@@ -431,20 +475,20 @@ func TestDashboardLayout_ColorDriftClearedByApply(t *testing.T) {
 			{
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("posthog_dashboard_layout.test", "tiles.0.color"),
+					resource.TestCheckNoResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr),
 					// Capture IDs for the API call in step 2
 					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources["posthog_dashboard.test"]
+						rs, ok := s.RootModule().Resources[dashboardResourceName]
 						if !ok {
-							return fmt.Errorf("resource not found: posthog_dashboard.test")
+							return fmt.Errorf(dashboardLayoutResourceNotFoundFmt, dashboardResourceName)
 						}
 						dashboardID = rs.Primary.ID
 
-						layout, ok := s.RootModule().Resources["posthog_dashboard_layout.test"]
+						layout, ok := s.RootModule().Resources[dashboardLayoutResourceName]
 						if !ok {
-							return fmt.Errorf("resource not found: posthog_dashboard_layout.test")
+							return fmt.Errorf(dashboardLayoutResourceNotFoundFmt, dashboardLayoutResourceName)
 						}
-						if _, err := fmt.Sscanf(layout.Primary.Attributes["tiles.0.tile_id"], "%d", &tileID); err != nil {
+						if _, err := fmt.Sscanf(layout.Primary.Attributes[dashboardLayoutFirstTileIDAttr], "%d", &tileID); err != nil {
 							return fmt.Errorf("parsing tile_id: %w", err)
 						}
 						return nil
@@ -473,7 +517,7 @@ func TestDashboardLayout_ColorDriftClearedByApply(t *testing.T) {
 				Config: testAccDashboardLayoutSingleInsight(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// After apply, color should be cleared back to absent
-					resource.TestCheckNoResourceAttr("posthog_dashboard_layout.test", "tiles.0.color"),
+					resource.TestCheckNoResourceAttr(dashboardLayoutResourceName, dashboardLayoutFirstTileColorAttr),
 					// Verify via API that the color was actually cleared
 					func(s *terraform.State) error {
 						resp, _, err := (&client).GetDashboardLayout(
@@ -541,6 +585,49 @@ resource "posthog_dashboard_layout" "test" {
   depends_on = [posthog_insight.test]
 }
 `, name, color)
+}
+
+func testAccDashboardLayoutInsightWithShowDescription(name, showDescription string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_dashboard" "test" {
+  name = %[1]q
+}
+
+resource "posthog_insight" "test" {
+  name = "%[1]s-insight"
+
+  query_json = jsonencode({
+    kind   = "InsightVizNode"
+    source = {
+      kind   = "TrendsQuery"
+      series = [{
+        kind  = "EventsNode"
+        event = "$pageview"
+        math  = "total"
+      }]
+    }
+  })
+
+  dashboard_ids = [posthog_dashboard.test.id]
+  depends_on    = [posthog_dashboard.test]
+}
+
+resource "posthog_dashboard_layout" "test" {
+  dashboard_id = posthog_dashboard.test.id
+
+  tiles = [
+    {
+      insight_id       = posthog_insight.test.id
+      show_description = %[2]s
+      layouts_json     = jsonencode({ sm = { x = 0, y = 0, w = 6, h = 4 } })
+    },
+  ]
+
+  depends_on = [posthog_insight.test]
+}
+`, name, showDescription)
 }
 
 // testAccDashboardLayoutUpdatedPosition returns HCL for the same layout as


### PR DESCRIPTION
## Summary
- expose `tiles.show_description` on `posthog_dashboard_layout`
- support explicit boolean updates and clearing back to the API default with `null`
- cover the new field in unit, acceptance, and generated docs/examples

## Validation
- `go test ./...`
- `TF_ACC=1 go test ./testacc -run 'TestDashboardLayout_ShowDescription' -v`\n- targeted real validation on the PostHog test project: plan/apply/re-plan and import/re-plan on the dashboard layout resource\n- local Sonar Quality Gate: passed