### PR TITLE
feat: add posthog_external_data_source resource

### DIFF
--- a/examples/resources/posthog_external_data_source/import.sh
+++ b/examples/resources/posthog_external_data_source/import.sh
@@ -1,0 +1,5 @@
+# Import using: project_id/external_data_source_id
+terraform import posthog_external_data_source.example 12345/01900000-0000-7000-8000-000000000000
+
+# If project_id is configured at the provider level, you can omit it:
+terraform import posthog_external_data_source.example 01900000-0000-7000-8000-000000000000

--- a/examples/resources/posthog_external_data_source/resource.tf
+++ b/examples/resources/posthog_external_data_source/resource.tf
@@ -1,0 +1,38 @@
+variable "stripe_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "pg_password" {
+  type      = string
+  sensitive = true
+}
+
+# Stripe warehouse source
+resource "posthog_external_data_source" "stripe" {
+  source_type    = "Stripe"
+  prefix         = "stripe_"
+  sync_frequency = "6hour"
+  schemas        = ["charges", "customers", "invoices"]
+
+  job_inputs_json = jsonencode({
+    stripe_account_id = "acct_123"
+    stripe_secret_key = var.stripe_secret_key
+  })
+}
+
+# Postgres warehouse source
+resource "posthog_external_data_source" "prod_pg" {
+  source_type    = "Postgres"
+  sync_frequency = "day"
+  schemas        = ["users", "orders"]
+
+  job_inputs_json = jsonencode({
+    host     = "db.internal"
+    port     = 5432
+    database = "app"
+    user     = "readonly"
+    password = var.pg_password
+    schema   = "public"
+  })
+}

--- a/internal/httpclient/external_data_source.go
+++ b/internal/httpclient/external_data_source.go
@@ -1,0 +1,47 @@
+package httpclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// ExternalDataSource represents a PostHog data warehouse source (Stripe, Postgres,
+// Snowflake, BigQuery, Hubspot, etc.) that syncs external data into PostHog.
+type ExternalDataSource struct {
+	ID         string                       `json:"id"`
+	SourceType string                       `json:"source_type"`
+	Prefix     *string                      `json:"prefix,omitempty"`
+	JobInputs  map[string]interface{}       `json:"job_inputs,omitempty"`
+	Schemas    []ExternalDataSourceSchema   `json:"schemas,omitempty"`
+	Status     *string                      `json:"status,omitempty"`
+	LastRunAt  *string                      `json:"last_run_at,omitempty"`
+	CreatedAt  *string                      `json:"created_at,omitempty"`
+}
+
+type ExternalDataSourceSchema struct {
+	Name          string  `json:"name"`
+	ShouldSync    bool    `json:"should_sync"`
+	SyncFrequency *string `json:"sync_frequency,omitempty"`
+	Status        *string `json:"status,omitempty"`
+}
+
+func (c *PosthogClient) CreateExternalDataSource(ctx context.Context, projectID string, input interface{}) (ExternalDataSource, error) {
+	path := fmt.Sprintf("/api/projects/%s/external_data_sources/", projectID)
+	result, _, err := doPost[ExternalDataSource](c, ctx, path, input)
+	return result, err
+}
+
+func (c *PosthogClient) GetExternalDataSource(ctx context.Context, projectID, id string) (ExternalDataSource, HTTPStatusCode, error) {
+	path := fmt.Sprintf("/api/projects/%s/external_data_sources/%s/", projectID, id)
+	return doGet[ExternalDataSource](c, ctx, path)
+}
+
+func (c *PosthogClient) UpdateExternalDataSource(ctx context.Context, projectID, id string, input interface{}) (ExternalDataSource, HTTPStatusCode, error) {
+	path := fmt.Sprintf("/api/projects/%s/external_data_sources/%s/", projectID, id)
+	return doPatch[ExternalDataSource](c, ctx, path, input)
+}
+
+func (c *PosthogClient) DeleteExternalDataSource(ctx context.Context, projectID, id string) (HTTPStatusCode, error) {
+	path := fmt.Sprintf("/api/projects/%s/external_data_sources/%s/", projectID, id)
+	return doDelete(c, ctx, path)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -141,6 +141,7 @@ func (p *PostHogProvider) Resources(_ context.Context) []func() frameworkresourc
 		posthogresource.NewAlert,
 		posthogresource.NewDashboard,
 		posthogresource.NewDashboardLayout,
+		posthogresource.NewExternalDataSource,
 		posthogresource.NewFeatureFlag,
 		posthogresource.NewHogFunction,
 		posthogresource.NewInsight,

--- a/internal/resource/external_data_source.go
+++ b/internal/resource/external_data_source.go
@@ -1,0 +1,291 @@
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/posthog/terraform-provider/internal/httpclient"
+	"github.com/posthog/terraform-provider/internal/resource/core"
+)
+
+func NewExternalDataSource() resource.Resource {
+	return core.NewGenericResource[ExternalDataSourceTFModel, map[string]interface{}, httpclient.ExternalDataSource](
+		ExternalDataSourceOps{},
+		core.ProjectScopedImportParser[ExternalDataSourceTFModel](),
+	)
+}
+
+type ExternalDataSourceTFModel struct {
+	core.BaseStringIdentifiable
+	core.BaseProjectID
+	SourceType    types.String `tfsdk:"source_type"`
+	Prefix        types.String `tfsdk:"prefix"`
+	JobInputsJSON types.String `tfsdk:"job_inputs_json"`
+	Schemas       types.List   `tfsdk:"schemas"`
+	SyncFrequency types.String `tfsdk:"sync_frequency"`
+	Status        types.String `tfsdk:"status"`
+	LastRunAt     types.String `tfsdk:"last_run_at"`
+	CreatedAt     types.String `tfsdk:"created_at"`
+}
+
+type ExternalDataSourceOps struct{}
+
+func (o ExternalDataSourceOps) ResourceName() string {
+	return "external_data_source"
+}
+
+func (o ExternalDataSourceOps) Schema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "PostHog external data warehouse source (e.g. Stripe, Hubspot, Postgres, MySQL, MSSQL, Snowflake, BigQuery, Salesforce, Zendesk, Vitally, Chargebee).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "External data source ID (UUID).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_id": core.ProjectIDSchemaAttribute(),
+			"source_type": schema.StringAttribute{
+				Required: true,
+				MarkdownDescription: "Source type. Values accepted by PostHog include " +
+					"`Stripe`, `Hubspot`, `Postgres`, `MySQL`, `MSSQL`, `Snowflake`, `BigQuery`, " +
+					"`Salesforce`, `Zendesk`, `Vitally`, `Chargebee`, `TemporalIO`. Cannot be changed after creation.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"prefix": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Optional prefix for synced table names (e.g. `stripe_prod_`). Useful when connecting multiple sources of the same type.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"job_inputs_json": schema.StringAttribute{
+				Required:  true,
+				Sensitive: true,
+				MarkdownDescription: "JSON-encoded connection configuration for the source. Shape depends on `source_type`. " +
+					"For example Postgres expects `{host, port, database, user, password, schema}`; Stripe expects `{stripe_account_id, stripe_secret_key}`. " +
+					"PostHog redacts secret values when reading, so the plan value is always preserved in state.",
+			},
+			"schemas": schema.ListAttribute{
+				Required:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "List of table names to sync from the source (e.g. `[\"users\", \"orders\"]`). PostHog discovers available tables from the source; these must match discovered table names.",
+			},
+			"sync_frequency": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "How often to sync. Managed per-schema by PostHog (e.g. `5min`, `30min`, `1hour`, `6hour`, `12hour`, `day`, `week`, `never`). Reports the sync frequency of the first schema.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"status": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Current status reported by PostHog (e.g. `Running`, `Completed`, `Error`).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_run_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Timestamp of the most recent sync run.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Timestamp when the source was created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (o ExternalDataSourceOps) BuildCreateRequest(ctx context.Context, model ExternalDataSourceTFModel) (map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Parse job_inputs_json into a flat map — these become top-level keys in the payload.
+	inputs, d := parseJobInputsJSON(model.JobInputsJSON)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	payload := make(map[string]interface{})
+	for k, v := range inputs {
+		payload[k] = v
+	}
+
+	if !model.Prefix.IsNull() && !model.Prefix.IsUnknown() {
+		payload["prefix"] = model.Prefix.ValueString()
+	}
+
+	// Build schemas array from the list of table names.
+	schemaNames, d := extractSchemaNames(ctx, model.Schemas)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	schemaEntries := make([]map[string]interface{}, 0, len(schemaNames))
+	for _, name := range schemaNames {
+		schemaEntries = append(schemaEntries, map[string]interface{}{
+			"name":        name,
+			"should_sync": true,
+		})
+	}
+	payload["schemas"] = schemaEntries
+
+	req := map[string]interface{}{
+		"source_type": model.SourceType.ValueString(),
+		"payload":     payload,
+	}
+
+	return req, diags
+}
+
+func (o ExternalDataSourceOps) BuildUpdateRequest(ctx context.Context, plan, state ExternalDataSourceTFModel) (map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	req := make(map[string]interface{})
+
+	if !plan.Prefix.IsNull() && !plan.Prefix.IsUnknown() {
+		req["prefix"] = plan.Prefix.ValueString()
+	} else if core.ShouldClearString(plan.Prefix, state.Prefix) {
+		req["prefix"] = ""
+	}
+
+	// Rebuild the payload with updated job_inputs if changed.
+	inputs, d := parseJobInputsJSON(plan.JobInputsJSON)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	payload := make(map[string]interface{})
+	for k, v := range inputs {
+		payload[k] = v
+	}
+
+	if len(payload) > 0 {
+		req["payload"] = payload
+	}
+
+	return req, diags
+}
+
+func (o ExternalDataSourceOps) MapResponseToModel(ctx context.Context, resp httpclient.ExternalDataSource, model *ExternalDataSourceTFModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	model.ID = types.StringValue(resp.ID)
+	if resp.SourceType != "" {
+		model.SourceType = types.StringValue(resp.SourceType)
+	}
+	// PostHog may not echo prefix back in the response even though it was
+	// accepted on create. Preserve the plan/state value when the API returns null.
+	if resp.Prefix != nil && strings.TrimSpace(*resp.Prefix) != "" {
+		model.Prefix = types.StringValue(strings.TrimSpace(*resp.Prefix))
+	}
+	model.Status = core.PtrToStringNullIfEmptyTrimmed(resp.Status)
+	model.LastRunAt = core.PtrToStringNullIfEmptyTrimmed(resp.LastRunAt)
+	model.CreatedAt = core.PtrToStringNullIfEmptyTrimmed(resp.CreatedAt)
+
+	// Derive sync_frequency from the first schema (PostHog stores it per-schema).
+	if len(resp.Schemas) > 0 && resp.Schemas[0].SyncFrequency != nil {
+		model.SyncFrequency = types.StringValue(*resp.Schemas[0].SyncFrequency)
+	} else if model.SyncFrequency.IsNull() || model.SyncFrequency.IsUnknown() {
+		model.SyncFrequency = types.StringNull()
+	}
+
+	// Map schema names from the response.
+	if len(resp.Schemas) > 0 {
+		names := make([]string, 0, len(resp.Schemas))
+		for _, s := range resp.Schemas {
+			names = append(names, s.Name)
+		}
+		listVal, d := types.ListValueFrom(ctx, types.StringType, names)
+		diags.Append(d...)
+		if !diags.HasError() {
+			model.Schemas = listVal
+		}
+	} else if model.Schemas.IsNull() || model.Schemas.IsUnknown() {
+		model.Schemas = types.ListNull(types.StringType)
+	}
+
+	// job_inputs_json contains credentials. PostHog redacts secret values on GET,
+	// so echoing the response would produce spurious diffs and "inconsistent values
+	// for sensitive attribute" errors. Keep the prior/planned value.
+	// On import (state is null), fall back to whatever PostHog returns so the user
+	// at least sees non-secret keys.
+	if model.JobInputsJSON.IsNull() || model.JobInputsJSON.IsUnknown() {
+		if len(resp.JobInputs) > 0 {
+			bytes, err := json.Marshal(resp.JobInputs)
+			if err != nil {
+				diags.AddError("Failed to marshal job_inputs", err.Error())
+				return diags
+			}
+			model.JobInputsJSON = types.StringValue(string(bytes))
+		} else {
+			model.JobInputsJSON = types.StringValue("{}")
+		}
+	}
+
+	return diags
+}
+
+func (o ExternalDataSourceOps) Create(ctx context.Context, client httpclient.PosthogClient, model ExternalDataSourceTFModel, req map[string]interface{}) (httpclient.ExternalDataSource, error) {
+	return client.CreateExternalDataSource(ctx, model.GetEffectiveProjectID(), req)
+}
+
+func (o ExternalDataSourceOps) Read(ctx context.Context, client httpclient.PosthogClient, model ExternalDataSourceTFModel) (httpclient.ExternalDataSource, httpclient.HTTPStatusCode, error) {
+	return client.GetExternalDataSource(ctx, model.GetEffectiveProjectID(), model.GetID())
+}
+
+func (o ExternalDataSourceOps) Update(ctx context.Context, client httpclient.PosthogClient, model ExternalDataSourceTFModel, req map[string]interface{}) (httpclient.ExternalDataSource, httpclient.HTTPStatusCode, error) {
+	return client.UpdateExternalDataSource(ctx, model.GetEffectiveProjectID(), model.GetID(), req)
+}
+
+func (o ExternalDataSourceOps) Delete(ctx context.Context, client httpclient.PosthogClient, model ExternalDataSourceTFModel) (httpclient.HTTPStatusCode, error) {
+	return client.DeleteExternalDataSource(ctx, model.GetEffectiveProjectID(), model.GetID())
+}
+
+func parseJobInputsJSON(v types.String) (map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if v.IsNull() || v.IsUnknown() {
+		return nil, diags
+	}
+	raw := strings.TrimSpace(v.ValueString())
+	if raw == "" {
+		return map[string]interface{}{}, diags
+	}
+	var inputs map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &inputs); err != nil {
+		diags.AddError("Invalid job_inputs_json", fmt.Sprintf("job_inputs_json must be a valid JSON object: %s", err.Error()))
+		return nil, diags
+	}
+	return inputs, diags
+}
+
+func extractSchemaNames(ctx context.Context, list types.List) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if list.IsNull() || list.IsUnknown() {
+		return nil, diags
+	}
+	var names []string
+	diags.Append(list.ElementsAs(ctx, &names, false)...)
+	return names, diags
+}

--- a/testacc/external_data_source_test.go
+++ b/testacc/external_data_source_test.go
@@ -1,0 +1,142 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/posthog/terraform-provider/internal/httpclient"
+)
+
+// Required env vars for Postgres external data source tests:
+//
+//	POSTHOG_TEST_PG_HOST
+//	POSTHOG_TEST_PG_PORT       (optional, defaults to 5432)
+//	POSTHOG_TEST_PG_DATABASE
+//	POSTHOG_TEST_PG_USER
+//	POSTHOG_TEST_PG_PASSWORD
+func skipIfNoPostgresCreds(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"POSTHOG_TEST_PG_HOST",
+		"POSTHOG_TEST_PG_DATABASE",
+		"POSTHOG_TEST_PG_USER",
+		"POSTHOG_TEST_PG_PASSWORD",
+	} {
+		if os.Getenv(v) == "" {
+			t.Skipf("Skipping test: %s not set", v)
+		}
+	}
+}
+
+func testAccCheckExternalDataSourceDestroy(s *terraform.State) error {
+	client := httpclient.NewDefaultClient(
+		os.Getenv("POSTHOG_HOST"),
+		os.Getenv("POSTHOG_API_KEY"),
+		"test",
+	)
+	projectID := os.Getenv("POSTHOG_PROJECT_ID")
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "posthog_external_data_source" {
+			continue
+		}
+
+		_, status, err := client.GetExternalDataSource(context.Background(), projectID, rs.Primary.ID)
+		if status == httpclient.HTTPStatusCode(http.StatusNotFound) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("unexpected error checking external data source %s: %w", rs.Primary.ID, err)
+		}
+		return fmt.Errorf("external data source %s still exists", rs.Primary.ID)
+	}
+
+	return nil
+}
+
+// TestExternalDataSource_InvalidJobInputs verifies that a malformed job_inputs_json
+// is rejected client-side without any API call. Requires no credentials.
+func TestExternalDataSource_InvalidJobInputs(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "posthog" {}
+
+resource "posthog_external_data_source" "test" {
+  source_type     = "Stripe"
+  job_inputs_json = "not-json"
+  schemas         = ["charges"]
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)invalid job_inputs_json`),
+			},
+		},
+	})
+}
+
+func TestExternalDataSource_Postgres_Basic(t *testing.T) {
+	skipIfNotAcceptance(t)
+	skipIfNoPostgresCreds(t)
+
+	rPrefix := acctest.RandomWithPrefix("tf_acc_")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckExternalDataSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExternalDataSourcePostgres(rPrefix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_external_data_source.test", "source_type", "Postgres"),
+					resource.TestCheckResourceAttrSet("posthog_external_data_source.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccExternalDataSourcePostgres(prefix string) string {
+	port := os.Getenv("POSTHOG_TEST_PG_PORT")
+	if port == "" {
+		port = "5432"
+	}
+
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_external_data_source" "test" {
+  source_type = "Postgres"
+  prefix      = %q
+  schemas     = ["test_data"]
+
+  job_inputs_json = jsonencode({
+    host     = %q
+    port     = %q
+    database = %q
+    user     = %q
+    password = %q
+    schema   = "public"
+  })
+}
+`,
+		prefix,
+		os.Getenv("POSTHOG_TEST_PG_HOST"),
+		port,
+		os.Getenv("POSTHOG_TEST_PG_DATABASE"),
+		os.Getenv("POSTHOG_TEST_PG_USER"),
+		os.Getenv("POSTHOG_TEST_PG_PASSWORD"),
+	)
+}


### PR DESCRIPTION
## Summary

- Adds `posthog_external_data_source` resource for managing external data warehouse sources (Postgres, Stripe, Hubspot, Snowflake, BigQuery, etc.)
- HTTP client CRUD against `/api/projects/{id}/external_data_sources/`
- Uses the generic resource pattern with proper payload envelope for PostHog's create API (`source_type` at top level + `payload` with flattened connection fields and `schemas`)
- `job_inputs_json` is marked sensitive — PostHog redacts secrets on GET, so the plan value is preserved in state
- `source_type` requires replacement on change
- `schemas` attribute specifies which discovered tables to sync
- `sync_frequency` is computed (managed per-schema by PostHog)

## Test plan

- [x] `TestExternalDataSource_InvalidJobInputs` — malformed JSON rejected client-side
- [x] `TestExternalDataSource_Postgres_Basic` — full create/read cycle against live PostHog EU with a real Postgres backend
- [x] Unit tests pass (`go test ./internal/...`)
- [x] Full build passes (`go build ./...`)