### PR TITLE
test(alert): align acceptance helpers with current PostHog spec

### DIFF
--- a/testacc/alert_test.go
+++ b/testacc/alert_test.go
@@ -404,6 +404,8 @@ resource "posthog_alert" "test" {
   subscribed_users = []
   threshold_type   = "absolute"
   threshold_upper  = 100
+  condition_type   = "absolute_value"
+  series_index     = 0
 
   depends_on = [posthog_insight.test]
 }
@@ -448,6 +450,8 @@ resource "posthog_alert" "test" {
   threshold_type   = "absolute"
   threshold_lower  = %d
   threshold_upper  = %d
+  condition_type   = "absolute_value"
+  series_index     = 0
 
   depends_on = [posthog_insight.test]
 }
@@ -467,6 +471,8 @@ resource "posthog_alert" "test" {
   enabled          = %t
   threshold_type   = "absolute"
   threshold_upper  = 100
+  condition_type   = "absolute_value"
+  series_index     = 0
 
   depends_on = [posthog_insight.test]
 }
@@ -486,6 +492,7 @@ resource "posthog_alert" "test" {
   threshold_type   = "absolute"
   threshold_upper  = 100
   condition_type   = %q
+  series_index     = 0
 
   depends_on = [posthog_insight.test]
 }
@@ -505,6 +512,8 @@ resource "posthog_alert" "test" {
   threshold_type       = "absolute"
   threshold_upper      = 100
   calculation_interval = %q
+  condition_type       = "absolute_value"
+  series_index         = 0
 
   depends_on = [posthog_insight.test]
 }
@@ -524,6 +533,8 @@ resource "posthog_alert" "test" {
   threshold_type         = "absolute"
   threshold_upper        = 100
   check_ongoing_interval = %t
+  condition_type         = "absolute_value"
+  series_index           = 0
 
   depends_on = [posthog_insight.test]
 }


### PR DESCRIPTION
## Summary

PostHog's alert API now requires every alert to provide a non-null `condition` (with a valid `type`) and a `config` block of `type: TrendsAlertConfig` with a `series_index` set. Several helpers in `testacc/alert_test.go` produced minimum-viable HCL that omitted these fields, so their generated POSTs failed validation with:

- `Alert has invalid condition: None` — missing `condition.type`
- `Unsupported alert config type: None` — missing `config` or its `type`

Spec sources in the main `posthog` repo:

- `posthog/tasks/alerts/utils.py:validate_alert_config` — required-field enforcement (lines ~61-86 on `master`)
- `posthog/schema.py` — `AlertCondition.type` is required; `TrendsAlertConfig.series_index` is required (`...` in Pydantic)

## Changes

Added `condition_type = "absolute_value"` and `series_index = 0` to every helper that lacked them:

- `testAccAlertBasic`
- `testAccAlertWithThreshold`
- `testAccAlertWithEnabled`
- `testAccAlertWithCondition` (already had `condition_type`; needed `series_index`)
- `testAccAlertWithInterval`
- `testAccAlertWithCheckOngoingInterval`

`testAccAlertAllFields` was already valid and is untouched.

## Notes

- `TestAlert_AllFields` can still fail with `Your plan is limited to 5 alerts` if the test project has accumulated alerts. That is a test-environment concern (clean up stale alerts on the project) and not addressed here.
- A follow-up worth considering: make `condition_type` `Required` and always emit a `TrendsAlertConfig` with a default `series_index = 0` in the provider itself, so end-users can't produce invalid-by-construction HCL. That would be a behavior change for existing configs and is out of scope here.

## Validation

- `go build ./...` passes
- `go vet ./testacc/` clean
- `go test ./...` passes (unit tests; acceptance tests require `TF_ACC=1` and a live PostHog)