### PR TITLE
fix: normalize imported insight queries

### DIFF
--- a/internal/resource/hog_function.go
+++ b/internal/resource/hog_function.go
@@ -18,6 +18,13 @@ import (
 	"github.com/posthog/terraform-provider/internal/util"
 )
 
+// hogFunctionServerFields are fields the server generates on hog-function
+// responses and should be stripped to avoid spurious diffs.
+var hogFunctionServerFields = map[string]struct{}{
+	"bytecode": {},
+	"order":    {},
+}
+
 func NewHogFunction() resource.Resource {
 	return core.NewGenericResource[HogFunctionResourceTFModel, httpclient.HogFunctionRequest, httpclient.HogFunction](
 		HogFunctionOps{},
@@ -498,35 +505,6 @@ func normalizeJSONStripServerFields(apiData interface{}, userJSON string) (strin
 		return "", nil
 	}
 
-	cleaned := stripServerFields(apiData)
+	cleaned := util.StripFields(apiData, hogFunctionServerFields)
 	return normalizeJSONForState(cleaned, userJSON)
-}
-
-// stripServerFields recursively removes server-computed fields from a value.
-func stripServerFields(v interface{}) interface{} {
-	// serverComputedFields are fields that the server generates and should be stripped
-	// from API responses to avoid spurious diffs.
-	var serverComputedFields = map[string]struct{}{
-		"bytecode": {},
-		"order":    {},
-	}
-
-	switch val := v.(type) {
-	case map[string]interface{}:
-		cleaned := make(map[string]interface{})
-		for k, v := range val {
-			if _, isServerField := serverComputedFields[k]; !isServerField {
-				cleaned[k] = stripServerFields(v)
-			}
-		}
-		return cleaned
-	case []interface{}:
-		cleaned := make([]interface{}, len(val))
-		for i, item := range val {
-			cleaned[i] = stripServerFields(item)
-		}
-		return cleaned
-	default:
-		return v
-	}
 }

--- a/internal/resource/hog_function_test.go
+++ b/internal/resource/hog_function_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/posthog/terraform-provider/internal/httpclient"
+	"github.com/posthog/terraform-provider/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -699,7 +700,7 @@ func TestStripServerFields(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := stripServerFields(tt.input)
+			result := util.StripFields(tt.input, hogFunctionServerFields)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/resource/insight.go
+++ b/internal/resource/insight.go
@@ -251,15 +251,51 @@ func normalizeQueryForState(apiQuery map[string]interface{}, userQueryJSON strin
 		return "", nil
 	}
 
+	cleanedQuery := stripInsightQueryServerFields(apiQuery)
+
+	userQueryJSON = strings.TrimSpace(userQueryJSON)
+	if userQueryJSON == "" {
+		return marshalJSON(cleanedQuery)
+	}
+
 	// Parse user's query to know which fields to keep
 	var userQuery map[string]interface{}
 	if err := json.Unmarshal([]byte(userQueryJSON), &userQuery); err != nil {
-		// If we can't parse user's query, fall back to returning API query as canonical JSON
-		return marshalJSON(apiQuery)
+		// If we can't parse user's query, fall back to returning a cleaned API query.
+		return marshalJSON(cleanedQuery)
 	}
 
-	filtered := filterToOnlyIncludeUserFields(userQuery, apiQuery)
+	filtered := filterToOnlyIncludeUserFields(userQuery, cleanedQuery)
 	return marshalJSON(filtered)
+}
+
+func stripInsightQueryServerFields(v interface{}) interface{} {
+	var serverComputedFields = map[string]struct{}{
+		"version":   {},
+		"result":    {},
+		"hogql":     {},
+		"is_cached": {},
+	}
+
+	switch val := v.(type) {
+	case map[string]interface{}:
+		cleaned := make(map[string]interface{}, len(val))
+		for key, value := range val {
+			if _, isServerField := serverComputedFields[key]; isServerField {
+				continue
+			}
+			cleaned[key] = stripInsightQueryServerFields(value)
+		}
+		return cleaned
+	case []interface{}:
+		cleaned := make([]interface{}, len(val))
+		for i, item := range val {
+			cleaned[i] = stripInsightQueryServerFields(item)
+		}
+		return cleaned
+	default:
+		return val
+	}
 }
 
 func marshalJSON(v interface{}) (string, error) {

--- a/internal/resource/insight.go
+++ b/internal/resource/insight.go
@@ -19,6 +19,15 @@ import (
 	"github.com/posthog/terraform-provider/internal/util"
 )
 
+// insightQueryServerFields are query-internal fields that PostHog injects on
+// response and would otherwise produce drift after import.
+var insightQueryServerFields = map[string]struct{}{
+	"version":   {},
+	"result":    {},
+	"hogql":     {},
+	"is_cached": {},
+}
+
 func NewInsight() resource.Resource {
 	return core.NewGenericResource[InsightResourceTFModel, httpclient.InsightRequest, httpclient.Insight](
 		InsightOps{},
@@ -251,7 +260,7 @@ func normalizeQueryForState(apiQuery map[string]interface{}, userQueryJSON strin
 		return "", nil
 	}
 
-	cleanedQuery := stripInsightQueryServerFields(apiQuery)
+	cleanedQuery := util.StripFields(apiQuery, insightQueryServerFields)
 
 	userQueryJSON = strings.TrimSpace(userQueryJSON)
 	if userQueryJSON == "" {
@@ -267,35 +276,6 @@ func normalizeQueryForState(apiQuery map[string]interface{}, userQueryJSON strin
 
 	filtered := filterToOnlyIncludeUserFields(userQuery, cleanedQuery)
 	return marshalJSON(filtered)
-}
-
-func stripInsightQueryServerFields(v interface{}) interface{} {
-	var serverComputedFields = map[string]struct{}{
-		"version":   {},
-		"result":    {},
-		"hogql":     {},
-		"is_cached": {},
-	}
-
-	switch val := v.(type) {
-	case map[string]interface{}:
-		cleaned := make(map[string]interface{}, len(val))
-		for key, value := range val {
-			if _, isServerField := serverComputedFields[key]; isServerField {
-				continue
-			}
-			cleaned[key] = stripInsightQueryServerFields(value)
-		}
-		return cleaned
-	case []interface{}:
-		cleaned := make([]interface{}, len(val))
-		for i, item := range val {
-			cleaned[i] = stripInsightQueryServerFields(item)
-		}
-		return cleaned
-	default:
-		return val
-	}
 }
 
 func marshalJSON(v interface{}) (string, error) {

--- a/internal/resource/insight_test.go
+++ b/internal/resource/insight_test.go
@@ -1,8 +1,11 @@
 package resource
 
 import (
+	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -192,10 +195,25 @@ func TestNormalizeQueryForState(t *testing.T) {
 		},
 		"falls back on invalid user JSON": {
 			apiQuery: map[string]interface{}{
-				"kind": "test",
+				"kind":    "test",
+				"version": float64(2),
 			},
 			userQueryJSON: `invalid json`,
 			expected:      `{"kind":"test"}`,
+		},
+		"strips server fields when user query is unavailable": {
+			apiQuery: map[string]interface{}{
+				"kind":      "DataVisualizationNode",
+				"result":    []interface{}{1, 2, 3},
+				"hogql":     "SELECT 1",
+				"is_cached": true,
+				"source": map[string]interface{}{
+					"kind":    "TrendsQuery",
+					"version": float64(2),
+				},
+			},
+			userQueryJSON: "",
+			expected:      `{"kind":"DataVisualizationNode","source":{"kind":"TrendsQuery"}}`,
 		},
 	}
 
@@ -206,4 +224,29 @@ func TestNormalizeQueryForState(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestInsightMapResponseToModel_StripsServerQueryFieldsWithoutUserConfig(t *testing.T) {
+	ops := InsightOps{}
+	model := InsightResourceTFModel{
+		QueryJSON: types.StringNull(),
+	}
+
+	resp := httpclient.Insight{
+		ID: 123,
+		Query: map[string]interface{}{
+			"kind":      "DataVisualizationNode",
+			"result":    []interface{}{1, 2, 3},
+			"hogql":     "SELECT 1",
+			"is_cached": true,
+			"source": map[string]interface{}{
+				"kind":    "TrendsQuery",
+				"version": float64(2),
+			},
+		},
+	}
+
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Equal(t, `{"kind":"DataVisualizationNode","source":{"kind":"TrendsQuery"}}`, model.QueryJSON.ValueString())
 }

--- a/internal/util/json.go
+++ b/internal/util/json.go
@@ -1,0 +1,26 @@
+package util
+
+// StripFields recursively returns a copy of v with any map keys named in
+// denylist removed. v is expected to be a JSON-decoded value (map, slice,
+// or scalar); other types are returned as-is.
+func StripFields(v interface{}, denylist map[string]struct{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		cleaned := make(map[string]interface{}, len(val))
+		for key, value := range val {
+			if _, isStripped := denylist[key]; isStripped {
+				continue
+			}
+			cleaned[key] = StripFields(value, denylist)
+		}
+		return cleaned
+	case []interface{}:
+		cleaned := make([]interface{}, len(val))
+		for i, item := range val {
+			cleaned[i] = StripFields(item, denylist)
+		}
+		return cleaned
+	default:
+		return val
+	}
+}

--- a/testacc/insight_test.go
+++ b/testacc/insight_test.go
@@ -300,7 +300,7 @@ func TestInsight_Import(t *testing.T) {
 				ResourceName:            "posthog_insight.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"query_json", "create_in_folder"},
+				ImportStateVerifyIgnore: []string{"create_in_folder"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Replaces #69 with one small refactor on top of @JulienJBO's original commit. Same primary fix, plus a tidy.

### From the original PR (commit `3033af5`)

- Strip server-computed fields from `posthog_insight.query_json` before normalizing it for state
- Keep imported insight state aligned with the configured query shape so the first post-import plan is clean
- Tighten the import test (`testacc/insight_test.go`) so `query_json` is verified instead of ignored

### Follow-up in this PR (commit `43988c4`)

**Consolidate the strip helper.** `stripServerFields` (in `hog_function.go`) and `stripInsightQueryServerFields` (in `insight.go`) had structurally identical recursive walkers — same logic, different denylist. Extracted both into a shared `util.StripFields(v, denylist)` in `internal/util/json.go` and have each resource declare its server-fields set as a package-level var (`hogFunctionServerFields`, `insightQueryServerFields`). Net: -25 lines of duplication, no behavior change for hog_function or insight.

## Validation

- `go build ./...`
- `go test ./...` — all packages pass
- Original author's manual validation still applies: `terraform state rm` + `terraform import` + `terraform plan` against a real PostHog test project produced `No changes`

## Notes

This PR is a copy of #69 with the consolidation suggestion applied. Once merged, #69 can be closed in favor of this one. Credit to @JulienJBO for the original fix, the test design, and the manual end-to-end validation.