### PR TITLE
feat(alert): require condition_type and series_index at provider level

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -17,7 +17,9 @@ Manage PostHog alerts. Alerts notify you when an insight's value crosses a thres
 
 ### Required
 
+- `condition_type` (String) Condition type: `absolute_value`, `relative_increase`, or `relative_decrease`.
 - `insight` (Number) ID of the insight this alert monitors.
+- `series_index` (Number) Index of the trend series to monitor (0-based). Used for trends alerts.
 - `subscribed_users` (Set of Number) List of user IDs to notify when the alert fires.
 - `threshold_type` (String) Type of threshold: `absolute` for fixed values, `percentage` for relative changes.
 
@@ -25,11 +27,9 @@ Manage PostHog alerts. Alerts notify you when an insight's value crosses a thres
 
 - `calculation_interval` (String) How often to check the alert: `hourly`, `daily`, `weekly`, or `monthly`.
 - `check_ongoing_interval` (Boolean) Whether to check the ongoing (incomplete) interval. When false, only completed intervals are checked.
-- `condition_type` (String) Condition type: `absolute_value`, `relative_increase`, or `relative_decrease`.
 - `enabled` (Boolean) Whether the alert is enabled. Defaults to true.
 - `name` (String) Name of the alert.
 - `project_id` (String) Project ID (environment) for this resource. Overrides the provider-level project_id.
-- `series_index` (Number) Index of the trend series to monitor (0-based). Used for trends alerts.
 - `skip_weekend` (Boolean) Whether to skip checking the alert on weekends.
 - `threshold_lower` (Number) Lower bound of the threshold. Alert fires when value goes below this.
 - `threshold_upper` (Number) Upper bound of the threshold. Alert fires when value goes above this.

--- a/docs/resources/feature_flag.md
+++ b/docs/resources/feature_flag.md
@@ -3,12 +3,12 @@
 page_title: "posthog_feature_flag Resource - posthog"
 subcategory: ""
 description: |-
-  PostHog Feature Flag resource. The current PostHog feature flag API exposes a display name, but not a separate dedicated description field.
+  PostHog Feature Flag resource
 ---
 
 # posthog_feature_flag (Resource)
 
-PostHog Feature Flag resource. The current PostHog feature flag API exposes a display `name`, but not a separate dedicated `description` field.
+PostHog Feature Flag resource
 
 
 
@@ -24,7 +24,7 @@ PostHog Feature Flag resource. The current PostHog feature flag API exposes a di
 - `active` (Boolean) Whether the feature flag is active
 - `deleted` (Boolean) Whether the feature flag is soft-deleted. Terraform will restore soft-deleted flags on apply.
 - `filters` (String) Feature flag filters as JSON
-- `name` (String) Feature flag display name. The current PostHog API does not expose a separate dedicated description field for feature flags.
+- `name` (String) Feature flag name/description (PostHog's UI labels this as 'Description'). The API does not expose a separate dedicated description field for feature flags.
 - `project_id` (String) Project ID (environment) for this resource. Overrides the provider-level project_id.
 - `rollout_percentage` (Number) Rollout percentage (0-100)
 - `tags` (Set of String) Set of tags for the feature flag

--- a/internal/resource/alert.go
+++ b/internal/resource/alert.go
@@ -3,13 +3,15 @@ package resource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/posthog/terraform-provider/internal/resource/core"
@@ -91,19 +93,21 @@ func (o AlertOps) Schema() schema.Schema {
 				MarkdownDescription: "Upper bound of the threshold. Alert fires when value goes above this.",
 			},
 			"condition_type": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
+				Required:            true,
 				MarkdownDescription: "Condition type: `absolute_value`, `relative_increase`, or `relative_decrease`.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"absolute_value",
+						"relative_increase",
+						"relative_decrease",
+					),
 				},
 			},
 			"series_index": schema.Int64Attribute{
-				Optional:            true,
-				Computed:            true,
+				Required:            true,
 				MarkdownDescription: "Index of the trend series to monitor (0-based). Used for trends alerts.",
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
 				},
 			},
 			"check_ongoing_interval": schema.BoolAttribute{
@@ -168,24 +172,18 @@ func (o AlertOps) BuildCreateRequest(ctx context.Context, model AlertResourceTFM
 		}
 	}
 
-	if !model.ConditionType.IsNull() && !model.ConditionType.IsUnknown() {
-		req.Condition = &httpclient.AlertCondition{
-			Type: model.ConditionType.ValueString(),
-		}
+	req.Condition = &httpclient.AlertCondition{
+		Type: model.ConditionType.ValueString(),
 	}
 
-	if !model.SeriesIndex.IsNull() && !model.SeriesIndex.IsUnknown() || !model.CheckOngoingInterval.IsNull() && !model.CheckOngoingInterval.IsUnknown() {
-		req.Config = &httpclient.TrendsAlertConfig{
-			Type: "TrendsAlertConfig",
-		}
-		if !model.SeriesIndex.IsNull() && !model.SeriesIndex.IsUnknown() {
-			seriesIndex := int(model.SeriesIndex.ValueInt64())
-			req.Config.SeriesIndex = &seriesIndex
-		}
-		if !model.CheckOngoingInterval.IsNull() && !model.CheckOngoingInterval.IsUnknown() {
-			checkOngoing := model.CheckOngoingInterval.ValueBool()
-			req.Config.CheckOngoingInterval = &checkOngoing
-		}
+	seriesIndex := int(model.SeriesIndex.ValueInt64())
+	req.Config = &httpclient.TrendsAlertConfig{
+		Type:        "TrendsAlertConfig",
+		SeriesIndex: &seriesIndex,
+	}
+	if !model.CheckOngoingInterval.IsNull() && !model.CheckOngoingInterval.IsUnknown() {
+		checkOngoing := model.CheckOngoingInterval.ValueBool()
+		req.Config.CheckOngoingInterval = &checkOngoing
 	}
 
 	if !model.CalculationInterval.IsNull() && !model.CalculationInterval.IsUnknown() {

--- a/testacc/alert_test.go
+++ b/testacc/alert_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -370,6 +371,46 @@ resource "posthog_insight" "test" {
 	})
 }
 
+// TestAlert_RejectsInvalidConditionType verifies that the OneOf validator on
+// `condition_type` rejects unknown values at plan time, before any API call.
+func TestAlert_RejectsInvalidConditionType(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAlertWithCondition(rName, "definitely_not_a_condition"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)condition_type.*value must be one of`),
+			},
+		},
+	})
+}
+
+// TestAlert_RejectsNegativeSeriesIndex verifies that the AtLeast(0) validator
+// on `series_index` rejects negative values at plan time, before any API call.
+func TestAlert_RejectsNegativeSeriesIndex(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAlertWithSeriesIndex(rName, -1),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)series_index.*value must be at least 0`),
+			},
+		},
+	})
+}
+
 // Helper function to create the base insight that alerts monitor
 func testAccAlertInsightBase(name string) string {
 	return fmt.Sprintf(`
@@ -539,4 +580,24 @@ resource "posthog_alert" "test" {
   depends_on = [posthog_insight.test]
 }
 `, testAccAlertInsightBase(name), name, checkOngoing)
+}
+
+func testAccAlertWithSeriesIndex(name string, seriesIndex int) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+%s
+
+resource "posthog_alert" "test" {
+  name             = %q
+  insight          = posthog_insight.test.id
+  subscribed_users = []
+  threshold_type   = "absolute"
+  threshold_upper  = 100
+  condition_type   = "absolute_value"
+  series_index     = %d
+
+  depends_on = [posthog_insight.test]
+}
+`, testAccAlertInsightBase(name), name, seriesIndex)
 }


### PR DESCRIPTION
Follow-up to #80. The PostHog alert API requires `condition.type` and
`config.series_index`, but the provider schema treated both as Optional,
so users could write configs that pass `terraform plan` and fail at
apply with cryptic API errors.

Both fields are now Required, with plan-time validators:

  - condition_type: stringvalidator.OneOf("absolute_value",
    "relative_increase", "relative_decrease")
  - series_index:   int64validator.AtLeast(0)

The TrendsAlertConfig and AlertCondition request blocks are now emitted
unconditionally, simplifying BuildCreateRequest. The int64planmodifier
import is removed (series_index was its only consumer).

Two ExpectError plan-time tests cover the new validators. Existing
acceptance helpers (updated by #80) already set both fields.

Note: this is a behaviour change for any pre-existing posthog_alert
configs that omitted these fields. Such configs were already broken
against the live API; the change surfaces the failure at plan time
instead of apply time.