### PR TITLE
feat: support ensure_experience_continuity on posthog_feature_flag

### DIFF
--- a/docs/resources/feature_flag.md
+++ b/docs/resources/feature_flag.md
@@ -23,6 +23,7 @@ PostHog Feature Flag resource
 
 - `active` (Boolean) Whether the feature flag is active
 - `deleted` (Boolean) Whether the feature flag is soft-deleted. Terraform will restore soft-deleted flags on apply.
+- `ensure_experience_continuity` (Boolean) Whether to persist the flag across authentication steps (PostHog's UI labels this as 'Persist flag across authentication steps'). Flags with experience continuity enabled cannot be evaluated by server-side local evaluation; set this to false for flags that must be evaluated locally.
 - `filters` (String) Feature flag filters as JSON
 - `name` (String) Feature flag name/description (PostHog's UI labels this as 'Description'). The API does not expose a separate dedicated description field for feature flags.
 - `project_id` (String) Project ID (environment) for this resource. Overrides the provider-level project_id.

--- a/examples/feature-flags/main.tf
+++ b/examples/feature-flags/main.tf
@@ -164,6 +164,27 @@ resource "posthog_feature_flag" "remote_config" {
   tags = ["managed-by:terraform"]
 }
 
+# Example 7: Server-Side Flag Without Experience Continuity
+# Pin `ensure_experience_continuity = false` so the flag can be evaluated by
+# server-side local evaluation. Flags with experience continuity enabled cannot
+# be computed locally, so a server-side gate would silently evaluate to false if
+# the setting were toggled on in the UI.
+resource "posthog_feature_flag" "server_side_gate" {
+  key                          = "server-side-gate"
+  name                         = "Server-Side Gate"
+  active                       = true
+  ensure_experience_continuity = false
+
+  filters = jsonencode({
+    groups = [{
+      properties         = []
+      rollout_percentage = 100
+    }]
+  })
+
+  tags = ["managed-by:terraform"]
+}
+
 # Outputs to reference the created feature flags
 output "simple_boolean_flag_id" {
   description = "ID of the simple boolean feature flag"

--- a/internal/httpclient/feature_flags.go
+++ b/internal/httpclient/feature_flags.go
@@ -6,23 +6,25 @@ import (
 )
 
 type FeatureFlag struct {
-	ID                int64                  `json:"id"`
-	Key               string                 `json:"key"`
-	Name              *string                `json:"name,omitempty"`
-	Active            *bool                  `json:"active,omitempty"`
-	Filters           map[string]interface{} `json:"filters,omitempty"`
-	RolloutPercentage *int32                 `json:"rollout_percentage,omitempty"`
-	Tags              []string               `json:"tags,omitempty"`
-	Deleted           *bool                  `json:"deleted,omitempty"`
+	ID                         int64                  `json:"id"`
+	Key                        string                 `json:"key"`
+	Name                       *string                `json:"name,omitempty"`
+	Active                     *bool                  `json:"active,omitempty"`
+	Filters                    map[string]interface{} `json:"filters,omitempty"`
+	RolloutPercentage          *int32                 `json:"rollout_percentage,omitempty"`
+	Tags                       []string               `json:"tags,omitempty"`
+	Deleted                    *bool                  `json:"deleted,omitempty"`
+	EnsureExperienceContinuity *bool                  `json:"ensure_experience_continuity,omitempty"`
 }
 
 type FeatureFlagRequest struct {
-	Key     string                 `json:"key"`
-	Name    *string                `json:"name,omitempty"`
-	Active  *bool                  `json:"active,omitempty"`
-	Filters map[string]interface{} `json:"filters,omitempty"`
-	Tags    []string               `json:"tags,omitempty"`
-	Deleted *bool                  `json:"deleted,omitempty"`
+	Key                        string                 `json:"key"`
+	Name                       *string                `json:"name,omitempty"`
+	Active                     *bool                  `json:"active,omitempty"`
+	Filters                    map[string]interface{} `json:"filters,omitempty"`
+	Tags                       []string               `json:"tags,omitempty"`
+	Deleted                    *bool                  `json:"deleted,omitempty"`
+	EnsureExperienceContinuity *bool                  `json:"ensure_experience_continuity,omitempty"`
 }
 
 func (c *PosthogClient) CreateFeatureFlag(ctx context.Context, projectID string, input FeatureFlagRequest) (FeatureFlag, error) {

--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -27,13 +27,14 @@ func NewFeatureFlag() resource.Resource {
 type FeatureFlagTFModel struct {
 	core.BaseInt64Identifiable
 	core.BaseProjectID
-	Key               types.String `tfsdk:"key"`
-	Name              types.String `tfsdk:"name"`
-	Active            types.Bool   `tfsdk:"active"`
-	Filters           types.String `tfsdk:"filters"`
-	RolloutPercentage types.Int64  `tfsdk:"rollout_percentage"`
-	Tags              types.Set    `tfsdk:"tags"`
-	Deleted           types.Bool   `tfsdk:"deleted"`
+	Key                        types.String `tfsdk:"key"`
+	Name                       types.String `tfsdk:"name"`
+	Active                     types.Bool   `tfsdk:"active"`
+	Filters                    types.String `tfsdk:"filters"`
+	RolloutPercentage          types.Int64  `tfsdk:"rollout_percentage"`
+	Tags                       types.Set    `tfsdk:"tags"`
+	Deleted                    types.Bool   `tfsdk:"deleted"`
+	EnsureExperienceContinuity types.Bool   `tfsdk:"ensure_experience_continuity"`
 }
 
 type FeatureFlagOps struct{}
@@ -70,6 +71,14 @@ func (o FeatureFlagOps) Schema() schema.Schema {
 				Optional:            true,
 				Computed:            true,
 				MarkdownDescription: "Whether the feature flag is active",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"ensure_experience_continuity": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether to persist the flag across authentication steps (PostHog's UI labels this as 'Persist flag across authentication steps'). Flags with experience continuity enabled cannot be evaluated by server-side local evaluation; set this to false for flags that must be evaluated locally.",
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
@@ -118,6 +127,11 @@ func (o FeatureFlagOps) BuildCreateRequest(ctx context.Context, model FeatureFla
 	if !model.Active.IsNull() {
 		active := model.Active.ValueBool()
 		req.Active = &active
+	}
+
+	if !model.EnsureExperienceContinuity.IsNull() {
+		ensureExperienceContinuity := model.EnsureExperienceContinuity.ValueBool()
+		req.EnsureExperienceContinuity = &ensureExperienceContinuity
 	}
 
 	// Handle filters and rollout_percentage
@@ -188,6 +202,11 @@ func (o FeatureFlagOps) BuildUpdateRequest(ctx context.Context, plan, state Feat
 		req.Active = &active
 	}
 
+	if !plan.EnsureExperienceContinuity.IsNull() {
+		ensureExperienceContinuity := plan.EnsureExperienceContinuity.ValueBool()
+		req.EnsureExperienceContinuity = &ensureExperienceContinuity
+	}
+
 	// Handle filters and rollout_percentage
 	var filters map[string]interface{}
 
@@ -247,6 +266,7 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	model.Key = types.StringValue(resp.Key)
 	model.Name = core.PtrToStringNullIfEmptyTrimmed(resp.Name)
 	model.Active = core.PtrToBool(resp.Active)
+	model.EnsureExperienceContinuity = core.PtrToBool(resp.EnsureExperienceContinuity)
 
 	// Set filters if present
 	if len(resp.Filters) > 0 {

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -35,3 +35,62 @@ func TestFeatureFlagMapResponseToModel_NormalizesServerOnlyFilterFields(t *testi
 	assert.Equal(t, `{"groups":[{"rollout_percentage":0}]}`, model.Filters.ValueString())
 	assert.Equal(t, int64(0), model.RolloutPercentage.ValueInt64())
 }
+
+func TestFeatureFlagBuildCreateRequestSetsEnsureExperienceContinuity(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Key:                        types.StringValue("my_flag"),
+		EnsureExperienceContinuity: types.BoolValue(false),
+	}
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.NotNil(t, req.EnsureExperienceContinuity)
+	assert.False(t, *req.EnsureExperienceContinuity)
+}
+
+func TestFeatureFlagBuildCreateRequestOmitsEnsureExperienceContinuityWhenNull(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Key: types.StringValue("my_flag"),
+	}
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Nil(t, req.EnsureExperienceContinuity)
+}
+
+func TestFeatureFlagBuildUpdateRequestSetsEnsureExperienceContinuity(t *testing.T) {
+	ops := FeatureFlagOps{}
+	plan := FeatureFlagTFModel{
+		Key:                        types.StringValue("my_flag"),
+		EnsureExperienceContinuity: types.BoolValue(true),
+	}
+
+	req, diags := ops.BuildUpdateRequest(context.Background(), plan, FeatureFlagTFModel{})
+	require.False(t, diags.HasError(), diags.Errors())
+	require.NotNil(t, req.EnsureExperienceContinuity)
+	assert.True(t, *req.EnsureExperienceContinuity)
+}
+
+func TestFeatureFlagMapResponseToModel_EnsureExperienceContinuity(t *testing.T) {
+	ops := FeatureFlagOps{}
+
+	enabled := true
+	respEnabled := httpclient.FeatureFlag{
+		ID:                         1,
+		Key:                        "my_flag",
+		EnsureExperienceContinuity: &enabled,
+	}
+	var modelEnabled FeatureFlagTFModel
+	diags := ops.MapResponseToModel(context.Background(), respEnabled, &modelEnabled)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.True(t, modelEnabled.EnsureExperienceContinuity.ValueBool())
+
+	// A nil pointer (field absent from the API response) maps to a null value.
+	respMissing := httpclient.FeatureFlag{ID: 2, Key: "my_flag"}
+	var modelMissing FeatureFlagTFModel
+	diags = ops.MapResponseToModel(context.Background(), respMissing, &modelMissing)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.True(t, modelMissing.EnsureExperienceContinuity.IsNull())
+}


### PR DESCRIPTION
## Motivation

The `posthog_feature_flag` resource currently exposes `key`, `active`, `deleted`, `filters`, `name`, `project_id`, `rollout_percentage`, and `tags`, but not `ensure_experience_continuity` — a top-level boolean on PostHog's feature-flag API (labeled "Persist flag across authentication steps" in the UI).

This matters for flags used as **server-side gates**. A flag with experience continuity enabled cannot be evaluated by server-side local evaluation — SDKs log `Unable to compute flag locally - Flag has experience continuity enabled`, and the flag silently evaluates to `false` everywhere a server relies on local evaluation. So a flag intended as a server-side gate breaks silently if experience continuity gets toggled on in the UI.

Exposing this field in Terraform lets teams pin it (typically to `false` for server-evaluated flags) and keep it under code review, preventing that silent breakage.

## What changed

- Add `ensure_experience_continuity` to the `FeatureFlag` and `FeatureFlagRequest` client structs (`*bool`, `json:"ensure_experience_continuity,omitempty"`), matching the existing nullable boolean fields.
- Add `ensure_experience_continuity` as an `Optional` + `Computed` boolean attribute on the resource, wired through schema → create → update → read mapping **exactly** like the existing `active` field (`UseStateForUnknown` plan modifier, `PtrToBool` mapping).
- Add a usage example (`examples/feature-flags/main.tf`).
- Regenerate resource docs via `make generate`.

## How tested

- `go build ./...` — clean.
- `go test ./internal/...` — all unit tests pass, including new tests covering that the field round-trips through `BuildCreateRequest`, `BuildUpdateRequest`, and `MapResponseToModel` (including the `nil` → null case).
- `golangci-lint run` and `go vet ./...` — clean.
- `make generate` — docs regenerated; diff is limited to the new attribute.

Acceptance tests (`make testacc`) were not run here as they require a live PostHog instance; the field follows the same code path as `active`, which is covered by the existing acceptance suite.
