### PR TITLE
feat: resolve organization_id from slug or @current (#99)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,5 +18,5 @@ description: |-
 
 - `api_key` (String, Sensitive) PostHog personal API key. Can be set via `POSTHOG_API_KEY` environment variable.
 - `host` (String) Base URL for the PostHog API. Defaults to `https://us.posthog.com`. Can be set via `POSTHOG_HOST`
-- `organization_id` (String) Default organization ID. Can be set via `POSTHOG_ORGANIZATION_ID` environment variable.
+- `organization_id` (String) Default organization to target. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization). Slugs and `@current` are resolved to a UUID for API calls. Can be set via `POSTHOG_ORGANIZATION_ID` environment variable.
 - `project_id` (String) Default project ID (environment) to target. Can be set via `POSTHOG_PROJECT_ID` environment variable.

--- a/docs/resources/organization_member.md
+++ b/docs/resources/organization_member.md
@@ -49,7 +49,7 @@ resource "posthog_organization_member" "alice" {
 ### Optional
 
 - `level` (String) The access level for the member. Valid values are 'member', 'admin', or 'owner'. Defaults to 'member'.
-- `organization_id` (String) Organization ID for this resource. Overrides the provider-level organization_id.
+- `organization_id` (String) Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.
 - `retain_on_destroy` (Boolean) If true, the user will remain in the organization when this resource is destroyed. Defaults to false.
 
 ### Read-Only

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -21,7 +21,7 @@ Manages a PostHog project within an organization.
 
 ### Optional
 
-- `organization_id` (String) Organization ID for this resource. Overrides the provider-level organization_id.
+- `organization_id` (String) Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.
 - `timezone` (String) The timezone for this project (e.g., 'UTC', 'America/New_York', 'Europe/London'). Defaults to 'UTC'.
 
 ### Read-Only

--- a/docs/resources/proxy_record.md
+++ b/docs/resources/proxy_record.md
@@ -34,7 +34,7 @@ output "analytics_proxy_target_cname" {
 
 ### Optional
 
-- `organization_id` (String) Organization ID for this resource. Overrides the provider-level organization_id.
+- `organization_id` (String) Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.
 
 ### Read-Only
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -38,7 +38,7 @@ resource "posthog_role" "support" {
 
 ### Optional
 
-- `organization_id` (String) Organization ID for this resource. Overrides the provider-level organization_id.
+- `organization_id` (String) Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.
 
 ### Read-Only
 

--- a/docs/resources/role_membership.md
+++ b/docs/resources/role_membership.md
@@ -46,7 +46,7 @@ resource "posthog_role_membership" "alice_engineering" {
 
 ### Optional
 
-- `organization_id` (String) Organization ID for this resource. Overrides the provider-level organization_id.
+- `organization_id` (String) Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.
 
 ### Read-Only
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -21,6 +22,21 @@ type PosthogClient struct {
 	apiKey     string
 	version    string
 	httpClient *http.Client
+	// orgCache memoizes organization slug/"@current" -> UUID resolutions. It is a
+	// pointer so that all value copies of PosthogClient (the client is passed by
+	// value through ProviderData and resource operations) share one cache.
+	orgCache *organizationCache
+}
+
+// organizationCache memoizes organization identifier resolutions across the
+// (value-copied) clients derived from a single constructed client.
+type organizationCache struct {
+	mu    sync.Mutex
+	byKey map[string]string
+}
+
+func newOrganizationCache() *organizationCache {
+	return &organizationCache{byKey: make(map[string]string)}
 }
 
 // PaginatedResponse is the standard envelope for paginated PostHog API list endpoints.
@@ -51,6 +67,7 @@ func NewDefaultClient(host, apiKey, version string, opts ...ClientOption) Postho
 		apiKey:     apiKey,
 		version:    version,
 		httpClient: httpClient,
+		orgCache:   newOrganizationCache(),
 	}
 }
 
@@ -64,6 +81,7 @@ func NewClient(client *http.Client, host, apiKey, version string, opts ...Client
 		apiKey:     apiKey,
 		version:    version,
 		httpClient: client,
+		orgCache:   newOrganizationCache(),
 	}
 }
 

--- a/internal/httpclient/organization.go
+++ b/internal/httpclient/organization.go
@@ -1,0 +1,108 @@
+package httpclient
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// CurrentOrganizationAlias is the special identifier PostHog accepts to refer to
+// the authenticated user's organization.
+const CurrentOrganizationAlias = "@current"
+
+// uuidPattern matches a canonical UUID (8-4-4-4-12 hex groups). PostHog
+// organization IDs are UUIDs, so anything matching this is treated as an ID and
+// passed through without an API call; anything else is treated as a slug.
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// Organization is a subset of the PostHog organization resource, containing the
+// fields needed to resolve a user-supplied slug or "@current" to a UUID.
+type Organization struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}
+
+// ListOrganizations returns all organizations the authenticated user can access.
+func (c *PosthogClient) ListOrganizations(ctx context.Context) ([]Organization, error) {
+	return listAll[Organization](c, ctx, "/api/organizations/")
+}
+
+// ResolveOrganizationID resolves a user-supplied organization identifier to a
+// UUID suitable for building API paths. It accepts:
+//   - a UUID, which is returned unchanged with no API call;
+//   - the literal "@current", resolved via GET /api/organizations/@current/;
+//   - an organization slug, resolved by listing organizations and matching slug.
+//
+// Resolution is purely for constructing request URLs — the caller must never
+// persist the resolved UUID back into Terraform state, otherwise a config that
+// uses a slug would show a permanent diff against the resolved UUID in state.
+//
+// Results are cached on the client (shared across copies via a pointer) so that
+// repeated calls across resources within a run do not refetch. The cache lock is
+// not held across the HTTP fetch, so a concurrent cold start (Terraform applies
+// resources in parallel) may issue a few redundant lookups for the same
+// identifier before the cache is populated; the result is idempotent (all writes
+// converge on the same UUID), so this is left uncollapsed rather than guarded
+// with single-flight, which would be disproportionate for a short-lived CLI run.
+func (c *PosthogClient) ResolveOrganizationID(ctx context.Context, idOrSlug string) (string, error) {
+	// An empty identifier means no organization is configured; pass it through
+	// unchanged and let the API surface the error, preserving prior behavior.
+	if idOrSlug == "" {
+		return "", nil
+	}
+
+	// UUIDs are already valid path segments; no resolution needed.
+	if uuidPattern.MatchString(idOrSlug) {
+		return idOrSlug, nil
+	}
+
+	if cached, ok := c.cachedOrganizationID(idOrSlug); ok {
+		return cached, nil
+	}
+
+	var resolved string
+	if idOrSlug == CurrentOrganizationAlias {
+		org, _, err := doGet[Organization](c, ctx, "/api/organizations/@current/")
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve %q organization: %w", CurrentOrganizationAlias, err)
+		}
+		resolved = org.ID
+	} else {
+		orgs, err := c.ListOrganizations(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list organizations to resolve slug %q: %w", idOrSlug, err)
+		}
+		for _, org := range orgs {
+			if org.Slug == idOrSlug {
+				resolved = org.ID
+				break
+			}
+		}
+		if resolved == "" {
+			return "", fmt.Errorf("no organization found matching slug %q; pass a valid organization UUID, slug, or %q", idOrSlug, CurrentOrganizationAlias)
+		}
+	}
+
+	c.storeOrganizationID(idOrSlug, resolved)
+	return resolved, nil
+}
+
+func (c *PosthogClient) cachedOrganizationID(key string) (string, bool) {
+	if c.orgCache == nil {
+		return "", false
+	}
+	c.orgCache.mu.Lock()
+	defer c.orgCache.mu.Unlock()
+	id, ok := c.orgCache.byKey[key]
+	return id, ok
+}
+
+func (c *PosthogClient) storeOrganizationID(key, id string) {
+	if c.orgCache == nil {
+		return
+	}
+	c.orgCache.mu.Lock()
+	defer c.orgCache.mu.Unlock()
+	c.orgCache.byKey[key] = id
+}

--- a/internal/httpclient/organization.go
+++ b/internal/httpclient/organization.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // CurrentOrganizationAlias is the special identifier PostHog accepts to refer to
@@ -58,17 +60,20 @@ func (c *PosthogClient) ResolveOrganizationID(ctx context.Context, idOrSlug stri
 	}
 
 	if cached, ok := c.cachedOrganizationID(idOrSlug); ok {
+		tflog.Trace(ctx, "resolved organization id from cache", map[string]any{"key": idOrSlug, "resolved_id": cached})
 		return cached, nil
 	}
 
 	var resolved string
 	if idOrSlug == CurrentOrganizationAlias {
+		tflog.Debug(ctx, "resolving @current organization via API", map[string]any{"key": idOrSlug})
 		org, _, err := doGet[Organization](c, ctx, "/api/organizations/@current/")
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve %q organization: %w", CurrentOrganizationAlias, err)
 		}
 		resolved = org.ID
 	} else {
+		tflog.Debug(ctx, "resolving organization slug via API", map[string]any{"key": idOrSlug})
 		orgs, err := c.ListOrganizations(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to list organizations to resolve slug %q: %w", idOrSlug, err)
@@ -85,7 +90,20 @@ func (c *PosthogClient) ResolveOrganizationID(ctx context.Context, idOrSlug stri
 	}
 
 	c.storeOrganizationID(idOrSlug, resolved)
+	tflog.Debug(ctx, "resolved and cached organization id", map[string]any{"key": idOrSlug, "resolved_id": resolved})
 	return resolved, nil
+}
+
+// orgPath resolves orgIDOrSlug (a UUID, slug, or "@current") to a UUID and formats
+// an org-scoped API path from it, with the resolved id as the first `%s`. It is the
+// single place client methods perform org resolution, so adding a new org-scoped
+// endpoint is a one-line call rather than a repeated resolve-and-check block.
+func (c *PosthogClient) orgPath(ctx context.Context, orgIDOrSlug, format string, args ...any) (string, error) {
+	orgID, err := c.ResolveOrganizationID(ctx, orgIDOrSlug)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(format, append([]any{orgID}, args...)...), nil
 }
 
 func (c *PosthogClient) cachedOrganizationID(key string) (string, bool) {

--- a/internal/httpclient/organization_member.go
+++ b/internal/httpclient/organization_member.go
@@ -26,18 +26,18 @@ type OrganizationMemberRequest struct {
 	Level *int `json:"level,omitempty"`
 }
 
-func (c *PosthogClient) ListOrganizationMembers(ctx context.Context, organizationID string) ([]OrganizationMember, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) ListOrganizationMembers(ctx context.Context, orgIDOrSlug string) ([]OrganizationMember, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/members/")
 	if err != nil {
 		return nil, err
 	}
-	return listAll[OrganizationMember](c, ctx, fmt.Sprintf("/api/organizations/%s/members/", organizationID))
+	return listAll[OrganizationMember](c, ctx, path)
 }
 
 // GetOrganizationMember retrieves a specific member by user UUID.
 // Since there's no direct GET endpoint, we list all members and filter.
-func (c *PosthogClient) GetOrganizationMember(ctx context.Context, organizationID, userUUID string) (OrganizationMember, HTTPStatusCode, error) {
-	members, err := c.ListOrganizationMembers(ctx, organizationID)
+func (c *PosthogClient) GetOrganizationMember(ctx context.Context, orgIDOrSlug, userUUID string) (OrganizationMember, HTTPStatusCode, error) {
+	members, err := c.ListOrganizationMembers(ctx, orgIDOrSlug)
 	if err != nil {
 		return OrganizationMember{}, 0, err
 	}
@@ -48,25 +48,23 @@ func (c *PosthogClient) GetOrganizationMember(ctx context.Context, organizationI
 		}
 	}
 
-	return OrganizationMember{}, http.StatusNotFound, fmt.Errorf("member with user UUID %s not found in organization %s", userUUID, organizationID)
+	return OrganizationMember{}, http.StatusNotFound, fmt.Errorf("member with user UUID %s not found in organization %s", userUUID, orgIDOrSlug)
 }
 
 // UpdateOrganizationMember updates a member's level.
-func (c *PosthogClient) UpdateOrganizationMember(ctx context.Context, organizationID, userUUID string, input OrganizationMemberRequest) (OrganizationMember, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) UpdateOrganizationMember(ctx context.Context, orgIDOrSlug, userUUID string, input OrganizationMemberRequest) (OrganizationMember, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/members/%s/", userUUID)
 	if err != nil {
 		return OrganizationMember{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/members/%s/", organizationID, userUUID)
 	return doPatch[OrganizationMember](c, ctx, path, input)
 }
 
 // DeleteOrganizationMember removes a member from the organization.
-func (c *PosthogClient) DeleteOrganizationMember(ctx context.Context, organizationID, userUUID string) (HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) DeleteOrganizationMember(ctx context.Context, orgIDOrSlug, userUUID string) (HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/members/%s/", userUUID)
 	if err != nil {
 		return 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/members/%s/", organizationID, userUUID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/organization_member.go
+++ b/internal/httpclient/organization_member.go
@@ -27,6 +27,10 @@ type OrganizationMemberRequest struct {
 }
 
 func (c *PosthogClient) ListOrganizationMembers(ctx context.Context, organizationID string) ([]OrganizationMember, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return nil, err
+	}
 	return listAll[OrganizationMember](c, ctx, fmt.Sprintf("/api/organizations/%s/members/", organizationID))
 }
 
@@ -49,12 +53,20 @@ func (c *PosthogClient) GetOrganizationMember(ctx context.Context, organizationI
 
 // UpdateOrganizationMember updates a member's level.
 func (c *PosthogClient) UpdateOrganizationMember(ctx context.Context, organizationID, userUUID string, input OrganizationMemberRequest) (OrganizationMember, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return OrganizationMember{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/members/%s/", organizationID, userUUID)
 	return doPatch[OrganizationMember](c, ctx, path, input)
 }
 
 // DeleteOrganizationMember removes a member from the organization.
 func (c *PosthogClient) DeleteOrganizationMember(ctx context.Context, organizationID, userUUID string) (HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/members/%s/", organizationID, userUUID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/organization_member_test.go
+++ b/internal/httpclient/organization_member_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestListOrganizationMembers_SinglePage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/organizations/org-123/members/", r.URL.Path, "request path should match expected endpoint")
+		assert.Equal(t, "/api/organizations/00000000-0000-0000-0000-000000000123/members/", r.URL.Path, "request path should match expected endpoint")
 
 		resp := PaginatedResponse[OrganizationMember]{
 			Results: []OrganizationMember{
@@ -29,7 +29,7 @@ func TestListOrganizationMembers_SinglePage(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.Client(), server.URL, "test-key", "test")
-	members, err := client.ListOrganizationMembers(context.Background(), "org-123")
+	members, err := client.ListOrganizationMembers(context.Background(), "00000000-0000-0000-0000-000000000123")
 
 	require.NoError(t, err, "listing organization members should not return an error")
 	assert.Len(t, members, 2, "should return all members from single page")
@@ -44,8 +44,8 @@ func TestListOrganizationMembers_MultiplePages(t *testing.T) {
 		requestURI := r.URL.RequestURI()
 
 		switch requestURI {
-		case "/api/organizations/org-123/members/":
-			nextURL := "/api/organizations/org-123/members/?cursor=page2"
+		case "/api/organizations/00000000-0000-0000-0000-000000000123/members/":
+			nextURL := "/api/organizations/00000000-0000-0000-0000-000000000123/members/?cursor=page2"
 			resp := PaginatedResponse[OrganizationMember]{
 				Results: []OrganizationMember{
 					{ID: "member-1", User: &OrganizationMemberUser{UUID: "user-1"}},
@@ -55,8 +55,8 @@ func TestListOrganizationMembers_MultiplePages(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(resp)
 
-		case "/api/organizations/org-123/members/?cursor=page2":
-			nextURL := "/api/organizations/org-123/members/?cursor=page3"
+		case "/api/organizations/00000000-0000-0000-0000-000000000123/members/?cursor=page2":
+			nextURL := "/api/organizations/00000000-0000-0000-0000-000000000123/members/?cursor=page3"
 			resp := PaginatedResponse[OrganizationMember]{
 				Results: []OrganizationMember{
 					{ID: "member-3", User: &OrganizationMemberUser{UUID: "user-3"}},
@@ -65,7 +65,7 @@ func TestListOrganizationMembers_MultiplePages(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(resp)
 
-		case "/api/organizations/org-123/members/?cursor=page3":
+		case "/api/organizations/00000000-0000-0000-0000-000000000123/members/?cursor=page3":
 			resp := PaginatedResponse[OrganizationMember]{
 				Results: []OrganizationMember{
 					{ID: "member-4", User: &OrganizationMemberUser{UUID: "user-4"}},
@@ -82,7 +82,7 @@ func TestListOrganizationMembers_MultiplePages(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.Client(), server.URL, "test-key", "test")
-	members, err := client.ListOrganizationMembers(context.Background(), "org-123")
+	members, err := client.ListOrganizationMembers(context.Background(), "00000000-0000-0000-0000-000000000123")
 
 	require.NoError(t, err, "listing organization members should not return an error")
 	assert.Len(t, members, 4, "should return all members from all pages")
@@ -110,7 +110,7 @@ func TestListOrganizationMembers_AbsoluteNextURL(t *testing.T) {
 
 		if requestCount == 1 {
 			// First page with absolute URL - tests that url.Parse extracts the path correctly
-			nextURL := "https://us.posthog.com/api/organizations/org-123/members/?cursor=page2"
+			nextURL := "https://us.posthog.com/api/organizations/00000000-0000-0000-0000-000000000123/members/?cursor=page2"
 			resp := PaginatedResponse[OrganizationMember]{
 				Results: []OrganizationMember{
 					{ID: "member-1", User: &OrganizationMemberUser{UUID: "user-1"}},
@@ -131,7 +131,7 @@ func TestListOrganizationMembers_AbsoluteNextURL(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.Client(), server.URL, "test-key", "test")
-	members, err := client.ListOrganizationMembers(context.Background(), "org-123")
+	members, err := client.ListOrganizationMembers(context.Background(), "00000000-0000-0000-0000-000000000123")
 
 	require.NoError(t, err, "listing organization members should not return an error")
 	assert.Len(t, members, 2, "should return members from both pages")
@@ -154,7 +154,7 @@ func TestGetOrganizationMember_Found(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.Client(), server.URL, "test-key", "test")
-	member, status, err := client.GetOrganizationMember(context.Background(), "org-123", "user-1")
+	member, status, err := client.GetOrganizationMember(context.Background(), "00000000-0000-0000-0000-000000000123", "user-1")
 
 	require.NoError(t, err, "getting existing organization member should not return an error")
 	assert.Equal(t, http.StatusOK, int(status), "should return 200 OK status")
@@ -177,7 +177,7 @@ func TestGetOrganizationMember_NotFound(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.Client(), server.URL, "test-key", "test")
-	_, status, err := client.GetOrganizationMember(context.Background(), "org-123", "user-999")
+	_, status, err := client.GetOrganizationMember(context.Background(), "00000000-0000-0000-0000-000000000123", "user-999")
 
 	require.Error(t, err, "getting non-existent organization member should return an error")
 	assert.Equal(t, http.StatusNotFound, int(status), "should return 404 Not Found status")

--- a/internal/httpclient/organization_test.go
+++ b/internal/httpclient/organization_test.go
@@ -1,0 +1,196 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testOrgUUID = "11111111-2222-3333-4444-555555555555"
+	testOrgSlug = "acme-corp"
+)
+
+func TestResolveOrganizationID_UUIDPassthrough(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		t.Errorf("unexpected HTTP request for UUID passthrough: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	resolved, err := client.ResolveOrganizationID(context.Background(), testOrgUUID)
+
+	require.NoError(t, err, "resolving a UUID should not error")
+	assert.Equal(t, testOrgUUID, resolved, "a UUID should be returned unchanged")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&requestCount), "resolving a UUID must not make any HTTP request")
+}
+
+func TestResolveOrganizationID_CurrentAlias(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/organizations/@current/", r.URL.Path, "@current should hit the @current endpoint")
+		writeJSONResponse(t, w, Organization{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	resolved, err := client.ResolveOrganizationID(context.Background(), CurrentOrganizationAlias)
+
+	require.NoError(t, err, "resolving @current should not error")
+	assert.Equal(t, testOrgUUID, resolved, "@current should resolve to the returned organization ID")
+}
+
+func TestResolveOrganizationID_SlugResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/organizations/", r.URL.Path, "slug resolution should list organizations")
+		resp := PaginatedResponse[Organization]{
+			Results: []Organization{
+				{ID: "99999999-8888-7777-6666-555555555555", Slug: "other-org", Name: "Other"},
+				{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"},
+			},
+		}
+		writeJSONResponse(t, w, resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	resolved, err := client.ResolveOrganizationID(context.Background(), testOrgSlug)
+
+	require.NoError(t, err, "resolving a known slug should not error")
+	assert.Equal(t, testOrgUUID, resolved, "slug should resolve to the matching organization ID")
+}
+
+func TestResolveOrganizationID_SlugNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := PaginatedResponse[Organization]{
+			Results: []Organization{
+				{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"},
+			},
+		}
+		writeJSONResponse(t, w, resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	_, err := client.ResolveOrganizationID(context.Background(), "does-not-exist")
+
+	require.Error(t, err, "resolving an unknown slug should return an error")
+	assert.Contains(t, err.Error(), "does-not-exist", "error should name the unresolved slug")
+}
+
+func TestResolveOrganizationID_CurrentAliasHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/organizations/@current/", r.URL.Path)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	_, err := client.ResolveOrganizationID(context.Background(), CurrentOrganizationAlias)
+
+	require.Error(t, err, "a non-2xx response from the @current endpoint should surface an error")
+	assert.Contains(t, err.Error(), CurrentOrganizationAlias, "error should reference the @current alias")
+}
+
+func TestResolveOrganizationID_SlugListHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/organizations/", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	_, err := client.ResolveOrganizationID(context.Background(), testOrgSlug)
+
+	require.Error(t, err, "an error listing organizations should surface during slug resolution")
+	assert.Contains(t, err.Error(), testOrgSlug, "error should reference the slug being resolved")
+}
+
+func TestResolveOrganizationID_CachesSlugResolution(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		resp := PaginatedResponse[Organization]{
+			Results: []Organization{
+				{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"},
+			},
+		}
+		writeJSONResponse(t, w, resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+
+	first, err := client.ResolveOrganizationID(context.Background(), testOrgSlug)
+	require.NoError(t, err, "first resolution should not error")
+	assert.Equal(t, testOrgUUID, first)
+
+	second, err := client.ResolveOrganizationID(context.Background(), testOrgSlug)
+	require.NoError(t, err, "second resolution should not error")
+	assert.Equal(t, testOrgUUID, second)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "second resolution should be served from cache without a new HTTP request")
+}
+
+func TestResolveOrganizationID_CachesCurrentAlias(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		writeJSONResponse(t, w, Organization{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+
+	first, err := client.ResolveOrganizationID(context.Background(), CurrentOrganizationAlias)
+	require.NoError(t, err, "first @current resolution should not error")
+	assert.Equal(t, testOrgUUID, first)
+
+	second, err := client.ResolveOrganizationID(context.Background(), CurrentOrganizationAlias)
+	require.NoError(t, err, "second @current resolution should not error")
+	assert.Equal(t, testOrgUUID, second)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "second @current resolution should be served from cache without a new HTTP request")
+}
+
+func TestResolveOrganizationID_CacheSharedAcrossClientCopies(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		resp := PaginatedResponse[Organization]{
+			Results: []Organization{{ID: testOrgUUID, Slug: testOrgSlug, Name: "Acme Corp"}},
+		}
+		writeJSONResponse(t, w, resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	_, err := client.ResolveOrganizationID(context.Background(), testOrgSlug)
+	require.NoError(t, err)
+
+	// PosthogClient is passed around by value; a copy must share the same cache.
+	clientCopy := client
+	resolved, err := clientCopy.ResolveOrganizationID(context.Background(), testOrgSlug)
+	require.NoError(t, err)
+	assert.Equal(t, testOrgUUID, resolved)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "a value copy of the client must reuse the shared resolution cache")
+}
+
+func TestResolveOrganizationID_EmptyPassthrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HTTP request for empty organization id: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), server.URL, testAPIKey, testClientVersion)
+	resolved, err := client.ResolveOrganizationID(context.Background(), "")
+
+	require.NoError(t, err, "empty organization id should pass through without error")
+	assert.Equal(t, "", resolved, "empty organization id should be returned unchanged")
+}

--- a/internal/httpclient/project.go
+++ b/internal/httpclient/project.go
@@ -19,22 +19,38 @@ type ProjectRequest struct {
 }
 
 func (c *PosthogClient) CreateProject(ctx context.Context, organizationID string, input ProjectRequest) (Project, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Project{}, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/projects/", organizationID)
 	result, _, err := doPost[Project](c, ctx, path, input)
 	return result, err
 }
 
 func (c *PosthogClient) GetProject(ctx context.Context, organizationID, projectID string) (Project, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Project{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doGet[Project](c, ctx, path)
 }
 
 func (c *PosthogClient) UpdateProject(ctx context.Context, organizationID, projectID string, input ProjectRequest) (Project, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Project{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doPatch[Project](c, ctx, path, input)
 }
 
 func (c *PosthogClient) DeleteProject(ctx context.Context, organizationID, projectID string) (HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/project.go
+++ b/internal/httpclient/project.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"context"
-	"fmt"
 )
 
 type Project struct {
@@ -18,39 +17,35 @@ type ProjectRequest struct {
 	Timezone *string `json:"timezone,omitempty"`
 }
 
-func (c *PosthogClient) CreateProject(ctx context.Context, organizationID string, input ProjectRequest) (Project, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) CreateProject(ctx context.Context, orgIDOrSlug string, input ProjectRequest) (Project, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/projects/")
 	if err != nil {
 		return Project{}, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/projects/", organizationID)
 	result, _, err := doPost[Project](c, ctx, path, input)
 	return result, err
 }
 
-func (c *PosthogClient) GetProject(ctx context.Context, organizationID, projectID string) (Project, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) GetProject(ctx context.Context, orgIDOrSlug, projectID string) (Project, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/projects/%s/", projectID)
 	if err != nil {
 		return Project{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doGet[Project](c, ctx, path)
 }
 
-func (c *PosthogClient) UpdateProject(ctx context.Context, organizationID, projectID string, input ProjectRequest) (Project, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) UpdateProject(ctx context.Context, orgIDOrSlug, projectID string, input ProjectRequest) (Project, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/projects/%s/", projectID)
 	if err != nil {
 		return Project{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doPatch[Project](c, ctx, path, input)
 }
 
-func (c *PosthogClient) DeleteProject(ctx context.Context, organizationID, projectID string) (HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) DeleteProject(ctx context.Context, orgIDOrSlug, projectID string) (HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/projects/%s/", projectID)
 	if err != nil {
 		return 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/projects/%s/", organizationID, projectID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/proxy_record.go
+++ b/internal/httpclient/proxy_record.go
@@ -26,6 +26,10 @@ type ProxyRecordListResponse struct {
 }
 
 func (c *PosthogClient) ListProxyRecords(ctx context.Context, organizationID string) ([]ProxyRecord, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return nil, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/proxy_records/", organizationID)
 	resp, _, err := doGet[ProxyRecordListResponse](c, ctx, path)
 	if err != nil {
@@ -35,17 +39,29 @@ func (c *PosthogClient) ListProxyRecords(ctx context.Context, organizationID str
 }
 
 func (c *PosthogClient) CreateProxyRecord(ctx context.Context, organizationID string, input ProxyRecordRequest) (ProxyRecord, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return ProxyRecord{}, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/proxy_records/", organizationID)
 	result, _, err := doPost[ProxyRecord](c, ctx, path, input)
 	return result, err
 }
 
 func (c *PosthogClient) GetProxyRecord(ctx context.Context, organizationID, proxyRecordID string) (ProxyRecord, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return ProxyRecord{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/proxy_records/%s/", organizationID, proxyRecordID)
 	return doGet[ProxyRecord](c, ctx, path)
 }
 
 func (c *PosthogClient) DeleteProxyRecord(ctx context.Context, organizationID, proxyRecordID string) (HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/proxy_records/%s/", organizationID, proxyRecordID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/proxy_record.go
+++ b/internal/httpclient/proxy_record.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"context"
-	"fmt"
 )
 
 type ProxyRecord struct {
@@ -25,12 +24,11 @@ type ProxyRecordListResponse struct {
 	Results         []ProxyRecord `json:"results"`
 }
 
-func (c *PosthogClient) ListProxyRecords(ctx context.Context, organizationID string) ([]ProxyRecord, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) ListProxyRecords(ctx context.Context, orgIDOrSlug string) ([]ProxyRecord, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/proxy_records/")
 	if err != nil {
 		return nil, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/proxy_records/", organizationID)
 	resp, _, err := doGet[ProxyRecordListResponse](c, ctx, path)
 	if err != nil {
 		return nil, err
@@ -38,30 +36,27 @@ func (c *PosthogClient) ListProxyRecords(ctx context.Context, organizationID str
 	return resp.Results, nil
 }
 
-func (c *PosthogClient) CreateProxyRecord(ctx context.Context, organizationID string, input ProxyRecordRequest) (ProxyRecord, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) CreateProxyRecord(ctx context.Context, orgIDOrSlug string, input ProxyRecordRequest) (ProxyRecord, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/proxy_records/")
 	if err != nil {
 		return ProxyRecord{}, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/proxy_records/", organizationID)
 	result, _, err := doPost[ProxyRecord](c, ctx, path, input)
 	return result, err
 }
 
-func (c *PosthogClient) GetProxyRecord(ctx context.Context, organizationID, proxyRecordID string) (ProxyRecord, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) GetProxyRecord(ctx context.Context, orgIDOrSlug, proxyRecordID string) (ProxyRecord, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/proxy_records/%s/", proxyRecordID)
 	if err != nil {
 		return ProxyRecord{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/proxy_records/%s/", organizationID, proxyRecordID)
 	return doGet[ProxyRecord](c, ctx, path)
 }
 
-func (c *PosthogClient) DeleteProxyRecord(ctx context.Context, organizationID, proxyRecordID string) (HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) DeleteProxyRecord(ctx context.Context, orgIDOrSlug, proxyRecordID string) (HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/proxy_records/%s/", proxyRecordID)
 	if err != nil {
 		return 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/proxy_records/%s/", organizationID, proxyRecordID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/proxy_record_test.go
+++ b/internal/httpclient/proxy_record_test.go
@@ -16,7 +16,7 @@ const (
 	testProxyRecordID          = "proxy-1"
 	testProxyRecordDomain      = "proxy.example.com"
 	testProxyRecordTargetCNAME = "abc.proxyhog.com."
-	testOrganizationID         = "org-123"
+	testOrganizationID         = "00000000-0000-0000-0000-000000000123"
 	testAPIKey                 = "test-key"
 	testClientVersion          = "test"
 	jsonContentTypeHeader      = "Content-Type"

--- a/internal/httpclient/role.go
+++ b/internal/httpclient/role.go
@@ -17,26 +17,46 @@ type RoleRequest struct {
 }
 
 func (c *PosthogClient) ListRoles(ctx context.Context, organizationID string) ([]Role, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return nil, err
+	}
 	return listAll[Role](c, ctx, fmt.Sprintf("/api/organizations/%s/roles/", organizationID))
 }
 
 func (c *PosthogClient) CreateRole(ctx context.Context, organizationID string, input RoleRequest) (Role, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Role{}, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/", organizationID)
 	result, _, err := doPost[Role](c, ctx, path, input)
 	return result, err
 }
 
 func (c *PosthogClient) GetRole(ctx context.Context, organizationID, roleID string) (Role, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Role{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doGet[Role](c, ctx, path)
 }
 
 func (c *PosthogClient) UpdateRole(ctx context.Context, organizationID, roleID string, input RoleRequest) (Role, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return Role{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doPatch[Role](c, ctx, path, input)
 }
 
 func (c *PosthogClient) DeleteRole(ctx context.Context, organizationID, roleID string) (HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/role.go
+++ b/internal/httpclient/role.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"context"
-	"fmt"
 )
 
 type Role struct {
@@ -16,47 +15,43 @@ type RoleRequest struct {
 	Name string `json:"name"`
 }
 
-func (c *PosthogClient) ListRoles(ctx context.Context, organizationID string) ([]Role, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) ListRoles(ctx context.Context, orgIDOrSlug string) ([]Role, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/")
 	if err != nil {
 		return nil, err
 	}
-	return listAll[Role](c, ctx, fmt.Sprintf("/api/organizations/%s/roles/", organizationID))
+	return listAll[Role](c, ctx, path)
 }
 
-func (c *PosthogClient) CreateRole(ctx context.Context, organizationID string, input RoleRequest) (Role, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) CreateRole(ctx context.Context, orgIDOrSlug string, input RoleRequest) (Role, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/")
 	if err != nil {
 		return Role{}, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/", organizationID)
 	result, _, err := doPost[Role](c, ctx, path, input)
 	return result, err
 }
 
-func (c *PosthogClient) GetRole(ctx context.Context, organizationID, roleID string) (Role, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) GetRole(ctx context.Context, orgIDOrSlug, roleID string) (Role, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/", roleID)
 	if err != nil {
 		return Role{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doGet[Role](c, ctx, path)
 }
 
-func (c *PosthogClient) UpdateRole(ctx context.Context, organizationID, roleID string, input RoleRequest) (Role, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) UpdateRole(ctx context.Context, orgIDOrSlug, roleID string, input RoleRequest) (Role, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/", roleID)
 	if err != nil {
 		return Role{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doPatch[Role](c, ctx, path, input)
 }
 
-func (c *PosthogClient) DeleteRole(ctx context.Context, organizationID, roleID string) (HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) DeleteRole(ctx context.Context, orgIDOrSlug, roleID string) (HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/", roleID)
 	if err != nil {
 		return 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/", organizationID, roleID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/role_membership.go
+++ b/internal/httpclient/role_membership.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"context"
-	"fmt"
 )
 
 type RoleMembershipUser struct {
@@ -21,30 +20,27 @@ type RoleMembershipRequest struct {
 	UserUUID string `json:"user_uuid"`
 }
 
-func (c *PosthogClient) CreateRoleMembership(ctx context.Context, organizationID, roleID string, input RoleMembershipRequest) (RoleMembership, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) CreateRoleMembership(ctx context.Context, orgIDOrSlug, roleID string, input RoleMembershipRequest) (RoleMembership, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/role_memberships/", roleID)
 	if err != nil {
 		return RoleMembership{}, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/", organizationID, roleID)
 	result, _, err := doPost[RoleMembership](c, ctx, path, input)
 	return result, err
 }
 
-func (c *PosthogClient) GetRoleMembership(ctx context.Context, organizationID, roleID, membershipID string) (RoleMembership, HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) GetRoleMembership(ctx context.Context, orgIDOrSlug, roleID, membershipID string) (RoleMembership, HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/role_memberships/%s/", roleID, membershipID)
 	if err != nil {
 		return RoleMembership{}, 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/%s/", organizationID, roleID, membershipID)
 	return doGet[RoleMembership](c, ctx, path)
 }
 
-func (c *PosthogClient) DeleteRoleMembership(ctx context.Context, organizationID, roleID, membershipID string) (HTTPStatusCode, error) {
-	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+func (c *PosthogClient) DeleteRoleMembership(ctx context.Context, orgIDOrSlug, roleID, membershipID string) (HTTPStatusCode, error) {
+	path, err := c.orgPath(ctx, orgIDOrSlug, "/api/organizations/%s/roles/%s/role_memberships/%s/", roleID, membershipID)
 	if err != nil {
 		return 0, err
 	}
-	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/%s/", organizationID, roleID, membershipID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/httpclient/role_membership.go
+++ b/internal/httpclient/role_membership.go
@@ -22,17 +22,29 @@ type RoleMembershipRequest struct {
 }
 
 func (c *PosthogClient) CreateRoleMembership(ctx context.Context, organizationID, roleID string, input RoleMembershipRequest) (RoleMembership, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return RoleMembership{}, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/", organizationID, roleID)
 	result, _, err := doPost[RoleMembership](c, ctx, path, input)
 	return result, err
 }
 
 func (c *PosthogClient) GetRoleMembership(ctx context.Context, organizationID, roleID, membershipID string) (RoleMembership, HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return RoleMembership{}, 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/%s/", organizationID, roleID, membershipID)
 	return doGet[RoleMembership](c, ctx, path)
 }
 
 func (c *PosthogClient) DeleteRoleMembership(ctx context.Context, organizationID, roleID, membershipID string) (HTTPStatusCode, error) {
+	organizationID, err := c.ResolveOrganizationID(ctx, organizationID)
+	if err != nil {
+		return 0, err
+	}
 	path := fmt.Sprintf("/api/organizations/%s/roles/%s/role_memberships/%s/", organizationID, roleID, membershipID)
 	return doDelete(c, ctx, path)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -81,7 +81,7 @@ func (p *PostHogProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 			"organization_id": schema.StringAttribute{
 				Optional: true,
 				MarkdownDescription: fmt.Sprintf(
-					"Default organization ID. Can be set via `%s` environment variable.", EnvPostHogOrganizationId,
+					"Default organization to target. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization). Slugs and `@current` are resolved to a UUID for API calls. Can be set via `%s` environment variable.", EnvPostHogOrganizationId,
 				),
 			},
 		},

--- a/internal/resource/core/helpers.go
+++ b/internal/resource/core/helpers.go
@@ -120,7 +120,7 @@ func OrganizationIDSchemaAttribute() schema.StringAttribute {
 	return schema.StringAttribute{
 		Optional:            true,
 		Computed:            true,
-		MarkdownDescription: "Organization ID for this resource. Overrides the provider-level organization_id.",
+		MarkdownDescription: "Organization for this resource. Overrides the provider-level organization_id. Accepts an organization UUID, an organization slug, or the literal `@current` (the authenticated user's organization); slugs and `@current` are resolved to a UUID for API calls while your original value is preserved in state.",
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.RequiresReplaceIfConfigured(),
 			stringplanmodifier.UseStateForUnknown(),

--- a/internal/resource/proxy_record_test.go
+++ b/internal/resource/proxy_record_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	testNormalizedProxyRecordDomain       = "proxy.example.com"
-	testProxyRecordOrganizationID         = "org-123"
+	testProxyRecordOrganizationID         = "00000000-0000-0000-0000-000000000123"
 	testProxyRecordIDValue                = "proxy-1"
 	testProxyRecordTargetCNAME            = "abc.proxyhog.com."
 	testProxyRecordStatus                 = "waiting"

--- a/testacc/project_test.go
+++ b/testacc/project_test.go
@@ -52,6 +52,7 @@ func TestProject_ProviderLevelOrganizationID(t *testing.T) {
 // portable across instances.
 func TestProject_OrganizationSlug(t *testing.T) {
 	skipIfNotAcceptance(t)
+	skipIfNoOrganizationID(t)
 
 	orgID := getOrganizationID()
 

--- a/testacc/project_test.go
+++ b/testacc/project_test.go
@@ -91,6 +91,31 @@ func TestProject_OrganizationSlug(t *testing.T) {
 	})
 }
 
+// TestProject_OrganizationCurrent exercises the "@current" resolution branch
+// (issue #99): organization_id is the literal "@current", which the provider
+// resolves to the authenticated user's org via GET /api/organizations/@current/.
+// State keeps "@current", not the resolved UUID.
+func TestProject_OrganizationCurrent(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccBasePreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectBasic("@current", rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_project.test", "name", rName),
+					resource.TestCheckResourceAttr("posthog_project.test", "organization_id", "@current"),
+					resource.TestCheckResourceAttrSet("posthog_project.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 // TestProject_Basic tests creating a project with only the required fields.
 func TestProject_Basic(t *testing.T) {
 	skipIfNotAcceptance(t)

--- a/testacc/project_test.go
+++ b/testacc/project_test.go
@@ -1,12 +1,15 @@
 package tests
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/posthog/terraform-provider/internal/httpclient"
 )
 
 func testAccProjectPreCheck(t *testing.T) {
@@ -33,6 +36,55 @@ func TestProject_ProviderLevelOrganizationID(t *testing.T) {
 					// Verify organization_id is set from provider default
 					resource.TestCheckResourceAttr("posthog_project.test", "organization_id", orgID),
 					resource.TestCheckResourceAttrSet("posthog_project.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestProject_OrganizationSlug exercises the slug-resolution path end-to-end
+// (issue #99): organization_id is given as the org's slug instead of its UUID.
+// Creation only succeeds if the provider resolves the slug to the org UUID when
+// building the org-scoped API path — and state must keep the slug, not the
+// resolved UUID, or every subsequent plan would show a permanent diff.
+//
+// The slug is derived from the configured org UUID at runtime so the test stays
+// portable across instances.
+func TestProject_OrganizationSlug(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	orgID := getOrganizationID()
+
+	client := httpclient.NewDefaultClient(os.Getenv("POSTHOG_HOST"), os.Getenv("POSTHOG_API_KEY"), "test")
+	orgs, err := client.ListOrganizations(context.Background())
+	if err != nil {
+		t.Fatalf("listing organizations to resolve slug: %v", err)
+	}
+	var slug string
+	for _, o := range orgs {
+		if o.ID == orgID {
+			slug = o.Slug
+			break
+		}
+	}
+	if slug == "" {
+		t.Skipf("organization %s has no slug; cannot exercise slug resolution", orgID)
+	}
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccProjectPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectBasic(slug, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_project.test", "name", rName),
+					// State keeps the slug the user wrote, not the resolved UUID.
+					resource.TestCheckResourceAttr("posthog_project.test", "organization_id", slug),
+					resource.TestCheckResourceAttrSet("posthog_project.test", "id"),
+					resource.TestCheckResourceAttrSet("posthog_project.test", "api_token"),
 				),
 			},
 		},


### PR DESCRIPTION
## What & why

Resolves #99. Lets `organization_id` (provider-level and per-resource) be given as an organization **slug** or the literal **`@current`**, not just a UUID.

PostHog's `OrganizationViewSet` has `lookup_field = "id"` (UUID only) plus a special case for `@current` (the authenticated user's org). There is **no slug-based routing server-side**, so resolution has to happen provider-side.

### The hook, and why state stays as the user's input

Resolution is localized **inside the org-scoped httpclient methods**, purely for building API paths. The resolved UUID is **never written back into Terraform state** — the user-facing `organization_id` attribute keeps whatever the user wrote (slug / `@current` / UUID).

This is load-bearing: if a user writes a slug in config and we stored the resolved UUID in state, every subsequent `plan` would show a permanent diff (`config slug != state UUID`). That's the same class of bug the existing `normalizeProxyRecordDomainPlanModifier` guards against. Because `GetEffectiveOrganizationID()` (the state-bearing model accessor) is left untouched and resolution happens only at path-construction time, state is never overwritten.

```mermaid
flowchart LR
  cfg["config: organization_id\n(uuid | slug | @current)"] --> model[TF model / state]
  model -->|GetEffectiveOrganizationID| ops[resource ops]
  ops -->|raw id-or-slug| cm[org-scoped client method]
  cm -->|ResolveOrganizationID| cache{cached?}
  cache -->|hit / UUID passthrough| uuid[UUID]
  cache -->|miss: @current or slug| api[(PostHog API)]
  api --> uuid
  uuid --> path["/api/organizations/UUID/..."]
  model -. user's original value persisted .-> state[(tfstate)]
```

## Changes

- New `internal/httpclient/organization.go`: `Organization`, `ListOrganizations`, and `ResolveOrganizationID(ctx, idOrSlug)`.
  - UUID -> passthrough, **no API call**.
  - `@current` -> `GET /api/organizations/@current/`.
  - slug -> list organizations, match `slug`, clear error if none match.
  - Pointer-backed, mutex-guarded cache on `PosthogClient` so it survives the client's pass-by-value copies (verified by a test).
- Wired resolution into every org-scoped path: project, proxy_record, organization_member, role, role_membership. `project_access` is project-scoped (`/api/projects/`) and intentionally untouched.
- Updated provider + per-resource `organization_id` descriptions; regenerated docs.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -s -w .` (clean on touched files)
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./internal/...` — all pass
- [x] `cd tools && go generate ./...` — docs regenerated and committed
- New unit tests (httptest): UUID passthrough (asserts **zero** HTTP calls), `@current`, slug->UUID, slug-not-found error, cache hit (asserts no re-request), `@current` cache hit, `@current` and list HTTP-error paths, cache shared across client value-copies, empty passthrough.
- [ ] **Acceptance tests (`make testacc`) need a maintainer run** — they require live PostHog API credentials not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Acceptance test evidence (verified locally)

Run against a live local PostHog (`POSTHOG_HOST=http://localhost:8010`, project `1`, org `hedgebox-inc`):

- **Unit** — `go test ./internal/...` ✅ PASS, including `organization_test.go`: UUID passthrough (no API call), `@current` resolution, slug→UUID resolution, slug-not-found error, and shared-cache-across-client-copies.
- **Acceptance (new)** — `TestProject_OrganizationSlug` ✅ PASS — sets `organization_id` to the org **slug**; the project only creates because the provider resolves the slug to the org UUID for the API path, and state keeps the slug (asserted), proving no perpetual diff.

```
--- PASS: TestProject_OrganizationSlug (2.51s)
ok  github.com/posthog/terraform-provider/testacc
```

- **Acceptance (regression)** — full `./testacc/...` run: all org-scoped resources (project, proxy_record, organization_member, role, role_membership) pass; no regression introduced by this PR. (The only failures in the full suite are a pre-existing `posthog_alert` `series_index` issue unrelated to this change, addressed separately in #102.)


**Update — all three resolver branches now have live acceptance coverage:**
```
--- PASS: TestProject_OrganizationSlug (12.71s)      # slug -> UUID
--- PASS: TestProject_OrganizationCurrent (9.58s)    # @current -> user's org
```
(UUID passthrough is exercised by every other org-scoped acceptance test.)
