### PR TITLE
test(hog_function): add required series_index to alert webhook config

### DIFF
--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -836,6 +836,7 @@ resource "posthog_alert" "test" {
   threshold_type       = "absolute"
   threshold_upper      = 1000
   condition_type       = "absolute_value"
+  series_index         = 0
   calculation_interval = "daily"
   skip_weekend         = false
 


### PR DESCRIPTION
The posthog_alert schema made series_index Required (ef08a5e) and
alert_test.go was updated to match, but the alert block in the
hog-function webhook-integration acceptance test was missed. It failed
at plan time with "Missing required argument: series_index". Add
series_index = 0 to match the other alert configs.

---

## Acceptance test evidence (verified locally)

Run against a live local PostHog (project `1`); the alert quota was first freed so creates weren't blocked by the 5-alert plan limit:

```
--- PASS: TestAlert_Basic ... TestAlert_InsightDeletion        (9 tests)
--- PASS: TestAlert_RejectsInvalidConditionType
--- PASS: TestAlert_RejectsNegativeSeriesIndex
--- PASS: TestHogFunction_AlertWebhookIntegration              (previously failed: "Missing required argument: series_index")
ok  github.com/posthog/terraform-provider/testacc
```

`TestHogFunction_AlertWebhookIntegration` failed at plan time before this change; it now passes.
