### PR TITLE
fix(hog_function): keep trailing whitespace in hog to avoid inconsistent-apply (#91)

### DIFF
--- a/internal/resource/core/helpers.go
+++ b/internal/resource/core/helpers.go
@@ -19,6 +19,14 @@ func PtrToStringNullIfEmptyTrimmed(v *string) types.String {
 	return types.StringValue(*v)
 }
 
+// TrimTrailingWS strips trailing whitespace (" \t\n\r"). It is the single source
+// of truth for the "trailing whitespace doesn't count" normalization that PostHog
+// applies server-side to code fields, so callers that compare against a trimmed
+// server value stay in sync with PtrToStringTrimmed.
+func TrimTrailingWS(s string) string {
+	return strings.TrimRight(s, " \t\n\r")
+}
+
 // PtrToStringTrimmed trims trailing whitespace from a string pointer.
 // Returns null if the pointer is nil or the trimmed result is empty.
 // Useful for multi-line code fields where trailing newlines can differ.
@@ -26,7 +34,7 @@ func PtrToStringTrimmed(v *string) types.String {
 	if v == nil {
 		return types.StringNull()
 	}
-	trimmed := strings.TrimRight(*v, " \t\n\r")
+	trimmed := TrimTrailingWS(*v)
 	if trimmed == "" {
 		return types.StringNull()
 	}

--- a/internal/resource/core/helpers.go
+++ b/internal/resource/core/helpers.go
@@ -19,10 +19,8 @@ func PtrToStringNullIfEmptyTrimmed(v *string) types.String {
 	return types.StringValue(*v)
 }
 
-// TrimTrailingWS strips trailing whitespace (" \t\n\r"). It is the single source
-// of truth for the "trailing whitespace doesn't count" normalization that PostHog
-// applies server-side to code fields, so callers that compare against a trimmed
-// server value stay in sync with PtrToStringTrimmed.
+// TrimTrailingWS matches the trailing-whitespace trimming PostHog applies
+// server-side, so configured and server values compare equal.
 func TrimTrailingWS(s string) string {
 	return strings.TrimRight(s, " \t\n\r")
 }

--- a/internal/resource/core/helpers_test.go
+++ b/internal/resource/core/helpers_test.go
@@ -58,6 +58,55 @@ func TestPtrToStringNullIfEmptyTrimmed(t *testing.T) {
 	}
 }
 
+func TestPtrToStringTrimmed(t *testing.T) {
+	tests := map[string]struct {
+		input    *string
+		wantNull bool
+		wantVal  string
+	}{
+		"nil returns null": {
+			input:    nil,
+			wantNull: true,
+		},
+		"empty string returns null": {
+			input:    ptr(""),
+			wantNull: true,
+		},
+		"whitespace-only returns null": {
+			input:    ptr("  \t\n\r "),
+			wantNull: true,
+		},
+		"trailing whitespace is trimmed": {
+			input:   ptr("code\n"),
+			wantVal: "code",
+		},
+		"mixed trailing whitespace is trimmed": {
+			input:   ptr("code  \t\n\r"),
+			wantVal: "code",
+		},
+		"no trailing whitespace is unchanged": {
+			input:   ptr("code"),
+			wantVal: "code",
+		},
+		"leading and interior whitespace is preserved": {
+			input:   ptr("  line1\n  line2\n"),
+			wantVal: "  line1\n  line2",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := PtrToStringTrimmed(tc.input)
+			if tc.wantNull {
+				assert.True(t, got.IsNull(), "expected null")
+				return
+			}
+			require.False(t, got.IsNull(), "expected non-null")
+			assert.Equal(t, tc.wantVal, got.ValueString())
+		})
+	}
+}
+
 func TestPtrToBool(t *testing.T) {
 	tests := map[string]struct {
 		input    *bool

--- a/internal/resource/hog_function.go
+++ b/internal/resource/hog_function.go
@@ -302,8 +302,20 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	model.Name = core.PtrToStringNullIfEmptyTrimmed(resp.Name)
 	model.Description = core.PtrToStringNullIfEmptyTrimmed(resp.Description)
 	model.Enabled = core.PtrToBool(resp.Enabled)
-	model.Hog = core.PtrToStringTrimmed(resp.Hog)
 	model.IconURL = core.PtrToStringNullIfEmptyTrimmed(resp.IconURL)
+
+	// Preserve the configured/prior hog value when it differs from the server's
+	// only by trailing whitespace. PostHog strips trailing whitespace (e.g. the
+	// newline a `<<-EOT` heredoc adds), so overwriting state with the server value
+	// would make the applied value differ from the known planned value — which
+	// Terraform rejects as "Provider produced inconsistent result after apply"
+	// (issue #91). Keeping the user's value treats the two as semantically equal,
+	// which also prevents a perpetual diff on subsequent plans.
+	serverHog := core.PtrToStringTrimmed(resp.Hog)
+	if model.Hog.IsNull() || model.Hog.IsUnknown() ||
+		strings.TrimRight(model.Hog.ValueString(), " \t\n\r") != serverHog.ValueString() {
+		model.Hog = serverHog
+	}
 
 	// TemplateID - only set if the model already has one (write-only field)
 	// The API returns template object, not template_id

--- a/internal/resource/hog_function.go
+++ b/internal/resource/hog_function.go
@@ -313,7 +313,7 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	// which also prevents a perpetual diff on subsequent plans.
 	serverHog := core.PtrToStringTrimmed(resp.Hog)
 	if model.Hog.IsNull() || model.Hog.IsUnknown() ||
-		strings.TrimRight(model.Hog.ValueString(), " \t\n\r") != serverHog.ValueString() {
+		core.TrimTrailingWS(model.Hog.ValueString()) != serverHog.ValueString() {
 		model.Hog = serverHog
 	}
 

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -956,6 +957,89 @@ resource "posthog_hog_function" "test" {
     }
   })
 
+  filters_json = jsonencode({
+    source = "events"
+    events = [{
+      id   = "$pageview"
+      name = "$pageview"
+      type = "events"
+    }]
+    filter_test_accounts = false
+  })
+}
+`, name)
+}
+
+// TestHogFunction_HogTrailingNewline is a regression test for issue #91. A raw
+// `<<-EOT` heredoc carries a trailing newline, which PostHog strips server-side.
+// Before the TrimTrailingWhitespace plan modifier, the known planned value (with
+// the newline) didn't match the server-trimmed value, producing "Provider
+// produced inconsistent result after apply". The modifier now trims the planned
+// value so plan == state — no chomp() workaround needed, and the post-apply plan
+// is empty (terraform-plugin-testing fails the step otherwise).
+func TestHogFunction_HogTrailingNewline(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHogFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHogFunctionHogTrailingNewline(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "id"),
+					// The fix preserves the user's configured value (trailing newline
+					// and all) so it stays semantically equal to the server's trimmed
+					// value — that's what keeps apply consistent and the plan empty.
+					resource.TestCheckResourceAttrWith("posthog_hog_function.test", "hog", func(v string) error {
+						if !strings.HasSuffix(v, "\n") {
+							return fmt.Errorf("expected hog to preserve its trailing newline, got %q", v)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// testAccHogFunctionHogTrailingNewline sets `hog` from a raw heredoc (no chomp),
+// so the configured value ends in a newline. This is the exact shape that
+// triggered issue #91 before the fix.
+func testAccHogFunctionHogTrailingNewline(name string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_hog_function" "test" {
+  name        = %q
+  description = "Regression test for trailing-newline hog code"
+  type        = "destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  hog = <<-EOT
+    let res := fetch(inputs.url, { 'method': 'POST', 'body': inputs.body });
+    if (res.status >= 400) {
+      throw Error(f'Webhook failed with status {res.status}');
+    }
+  EOT
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/webhook"
+      templating = "hog"
+    }
+    body = {
+      value      = { event = "{event.event}" }
+      templating = "hog"
+    }
+  })
+
+  # Set explicitly so the template's default filters don't surface as a
+  # null-vs-value inconsistency unrelated to the hog field under test.
   filters_json = jsonencode({
     source = "events"
     events = [{

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -972,11 +972,12 @@ resource "posthog_hog_function" "test" {
 
 // TestHogFunction_HogTrailingNewline is a regression test for issue #91. A raw
 // `<<-EOT` heredoc carries a trailing newline, which PostHog strips server-side.
-// Before the TrimTrailingWhitespace plan modifier, the known planned value (with
-// the newline) didn't match the server-trimmed value, producing "Provider
-// produced inconsistent result after apply". The modifier now trims the planned
-// value so plan == state — no chomp() workaround needed, and the post-apply plan
-// is empty (terraform-plugin-testing fails the step otherwise).
+// Storing the server-trimmed value made the applied value differ from the known
+// planned (config) value, producing "Provider produced inconsistent result after
+// apply". The fix keeps the configured value in MapResponseToModel when it differs
+// from the server's only by trailing whitespace (semantic equality), so apply is
+// consistent and the post-apply plan is empty (terraform-plugin-testing fails the
+// step otherwise) — no chomp() workaround needed.
 func TestHogFunction_HogTrailingNewline(t *testing.T) {
 	skipIfNotAcceptance(t)
 


### PR DESCRIPTION
PostHog strips trailing whitespace from hog server-side. The resource
stored the server-trimmed value, so a config with a trailing newline (any
<<-EOT heredoc) produced a planned value that didn't match the applied
value — "Provider produced inconsistent result after apply".

A plan modifier that trimmed the planned value was tried first, but
Terraform core rejects rewriting a known configured value to a different
known value ("Provider produced invalid plan"). Instead, MapResponseToModel
now keeps the configured/prior value when it differs from the server's only
by trailing whitespace (semantic equality) — the same approach already used
for sensitive_inputs_json.

Adds an acceptance regression test using a raw heredoc (no chomp workaround).

---

## Acceptance test evidence (verified locally)

Run against a live local PostHog (project `1`):

- **Unit** — `go test ./internal/...` ✅ PASS, including new `TestPtrToStringTrimmed` coverage for the now load-bearing trim helper.
- **Acceptance (new regression)** — `TestHogFunction_HogTrailingNewline` ✅ PASS — applies a raw `<<-EOT` heredoc (no `chomp()`); before the fix this produced "Provider produced inconsistent result after apply", and the implicit post-apply plan check confirms idempotency.
- **Acceptance (regression)** — full `TestHogFunction_*` suite ✅ PASS (no regression from the `MapResponseToModel` change).

```
--- PASS: TestHogFunction_HogTrailingNewline (1.70s)
--- PASS: TestHogFunction_WebhookDestination ... InputsSchemaJSON   (11 tests)
ok  github.com/posthog/terraform-provider/testacc
```

> Note: a plan-modifier approach was tried first and rejected by Terraform core ("Provider produced invalid plan" — it forbids rewriting a known configured value); the shipped fix uses semantic equality in `MapResponseToModel` instead.
