### PR TITLE
fix(proxy_record): strip trailing dot from target_cname (#105)

### DIFF
--- a/docs/resources/proxy_record.md
+++ b/docs/resources/proxy_record.md
@@ -43,7 +43,7 @@ output "analytics_proxy_target_cname" {
 - `id` (String) The UUID of the proxy record.
 - `message` (String) Additional status detail returned by PostHog, when present.
 - `status` (String) The current provisioning status reported by PostHog.
-- `target_cname` (String) The PostHog-managed CNAME target that your DNS record must point to.
+- `target_cname` (String) The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content.
 - `updated_at` (String) Timestamp when the proxy record was last updated.
 
 ## Import

--- a/docs/resources/proxy_record.md
+++ b/docs/resources/proxy_record.md
@@ -43,7 +43,7 @@ output "analytics_proxy_target_cname" {
 - `id` (String) The UUID of the proxy record.
 - `message` (String) Additional status detail returned by PostHog, when present.
 - `status` (String) The current provisioning status reported by PostHog.
-- `target_cname` (String) The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content.
+- `target_cname` (String) The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content. If your DNS provider requires the DNS-canonical dotted form (e.g. `hashicorp/dns`), append it yourself: `"${posthog_proxy_record.example.target_cname}."`.
 - `updated_at` (String) Timestamp when the proxy record was last updated.
 
 ## Import

--- a/internal/resource/proxy_record.go
+++ b/internal/resource/proxy_record.go
@@ -77,7 +77,7 @@ func (o ProxyRecordOps) Schema() schema.Schema {
 					normalizeProxyRecordDomainPlanModifier{},
 				},
 			},
-			"target_cname": proxyRecordComputedStringAttribute("The PostHog-managed CNAME target that your DNS record must point to."),
+			"target_cname": proxyRecordComputedStringAttribute("The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content."),
 			"status":       proxyRecordComputedStringAttribute("The current provisioning status reported by PostHog."),
 			"message":      proxyRecordComputedStringAttribute("Additional status detail returned by PostHog, when present."),
 			"created_at":   proxyRecordComputedStringAttribute("Timestamp when the proxy record was created."),
@@ -108,7 +108,11 @@ func (o ProxyRecordOps) MapResponseToModel(_ context.Context, resp httpclient.Pr
 
 	model.ID = types.StringValue(resp.ID)
 	model.Domain = types.StringValue(resp.Domain)
-	model.TargetCNAME = types.StringValue(resp.TargetCNAME)
+	// PostHog emits target_cname as a DNS-canonical FQDN with a trailing dot.
+	// Most DNS providers (Cloudflare, Route53) store record content without it,
+	// so passing the dot through causes a perpetual diff on the downstream DNS
+	// resource (https://github.com/PostHog/terraform-provider-posthog/issues/105).
+	model.TargetCNAME = types.StringValue(strings.TrimSuffix(resp.TargetCNAME, "."))
 	model.Status = types.StringValue(resp.Status)
 	model.Message = core.PtrToStringNullIfEmptyTrimmed(resp.Message)
 	model.CreatedAt = core.PtrToStringNullIfEmptyTrimmed(resp.CreatedAt)

--- a/internal/resource/proxy_record.go
+++ b/internal/resource/proxy_record.go
@@ -112,7 +112,7 @@ func (o ProxyRecordOps) MapResponseToModel(_ context.Context, resp httpclient.Pr
 	// Most DNS providers (Cloudflare, Route53) store record content without it,
 	// so passing the dot through causes a perpetual diff on the downstream DNS
 	// resource (https://github.com/PostHog/terraform-provider-posthog/issues/105).
-	model.TargetCNAME = types.StringValue(strings.TrimSuffix(resp.TargetCNAME, "."))
+	model.TargetCNAME = types.StringValue(trimTrailingDot(resp.TargetCNAME))
 	model.Status = types.StringValue(resp.Status)
 	model.Message = core.PtrToStringNullIfEmptyTrimmed(resp.Message)
 	model.CreatedAt = core.PtrToStringNullIfEmptyTrimmed(resp.CreatedAt)
@@ -139,7 +139,11 @@ func (o ProxyRecordOps) Delete(ctx context.Context, client httpclient.PosthogCli
 }
 
 func normalizeProxyRecordDomain(raw string) string {
-	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(raw), "."))
+	return strings.ToLower(trimTrailingDot(strings.TrimSpace(raw)))
+}
+
+func trimTrailingDot(fqdn string) string {
+	return strings.TrimSuffix(fqdn, ".")
 }
 
 // normalizeProxyRecordDomainPlanModifier rewrites the planned `domain` value

--- a/internal/resource/proxy_record.go
+++ b/internal/resource/proxy_record.go
@@ -77,7 +77,7 @@ func (o ProxyRecordOps) Schema() schema.Schema {
 					normalizeProxyRecordDomainPlanModifier{},
 				},
 			},
-			"target_cname": proxyRecordComputedStringAttribute("The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content."),
+			"target_cname": proxyRecordComputedStringAttribute("The PostHog-managed CNAME target that your DNS record must point to. Normalised without a trailing dot, ready to use as DNS record content. If your DNS provider requires the DNS-canonical dotted form (e.g. `hashicorp/dns`), append it yourself: `\"${posthog_proxy_record.example.target_cname}.\"`."),
 			"status":       proxyRecordComputedStringAttribute("The current provisioning status reported by PostHog."),
 			"message":      proxyRecordComputedStringAttribute("Additional status detail returned by PostHog, when present."),
 			"created_at":   proxyRecordComputedStringAttribute("Timestamp when the proxy record was created."),

--- a/internal/resource/proxy_record_test.go
+++ b/internal/resource/proxy_record_test.go
@@ -173,22 +173,6 @@ func TestProxyRecordMapResponseToModel(t *testing.T) {
 	assert.True(t, model.Message.IsNull())
 }
 
-func TestProxyRecordMapResponseToModel_TargetCNAMEWithoutTrailingDot(t *testing.T) {
-	ops := ProxyRecordOps{}
-	resp := httpclient.ProxyRecord{
-		ID:          testProxyRecordIDValue,
-		Domain:      testNormalizedProxyRecordDomain,
-		TargetCNAME: testNormalizedProxyRecordTargetCNAME,
-		Status:      testProxyRecordStatus,
-	}
-
-	var model ProxyRecordTFModel
-	diags := ops.MapResponseToModel(context.Background(), resp, &model)
-
-	assert.False(t, diags.HasError())
-	assert.Equal(t, testNormalizedProxyRecordTargetCNAME, model.TargetCNAME.ValueString())
-}
-
 func TestProxyRecordMapResponseToModel_WithMessageAndNilCreator(t *testing.T) {
 	ops := ProxyRecordOps{}
 	message := "Waiting on DNS"

--- a/internal/resource/proxy_record_test.go
+++ b/internal/resource/proxy_record_test.go
@@ -18,18 +18,19 @@ import (
 )
 
 const (
-	testNormalizedProxyRecordDomain       = "proxy.example.com"
-	testProxyRecordOrganizationID         = "00000000-0000-0000-0000-000000000123"
-	testProxyRecordIDValue                = "proxy-1"
-	testProxyRecordTargetCNAME            = "abc.proxyhog.com."
-	testProxyRecordStatus                 = "waiting"
-	testProxyRecordCreatedAt              = "2026-04-21T07:13:42.440644Z"
-	testProxyRecordUpdatedAt              = "2026-04-21T07:13:42.440655Z"
-	testProxyRecordAPIKey                 = "test-key"
-	testProxyRecordClientVersion          = "test"
-	testProxyRecordCreatorID        int64 = 432419
-	testProxyRecordAPIPathPrefix          = "/api/organizations/"
-	testProxyRecordAPIPathSuffix          = "/proxy_records/"
+	testNormalizedProxyRecordDomain            = "proxy.example.com"
+	testProxyRecordOrganizationID              = "00000000-0000-0000-0000-000000000123"
+	testProxyRecordIDValue                     = "proxy-1"
+	testProxyRecordTargetCNAME                 = "abc.proxyhog.com."
+	testNormalizedProxyRecordTargetCNAME       = "abc.proxyhog.com"
+	testProxyRecordStatus                      = "waiting"
+	testProxyRecordCreatedAt                   = "2026-04-21T07:13:42.440644Z"
+	testProxyRecordUpdatedAt                   = "2026-04-21T07:13:42.440655Z"
+	testProxyRecordAPIKey                      = "test-key"
+	testProxyRecordClientVersion               = "test"
+	testProxyRecordCreatorID             int64 = 432419
+	testProxyRecordAPIPathPrefix               = "/api/organizations/"
+	testProxyRecordAPIPathSuffix               = "/proxy_records/"
 )
 
 func TestNormalizeProxyRecordDomain(t *testing.T) {
@@ -164,12 +165,28 @@ func TestProxyRecordMapResponseToModel(t *testing.T) {
 	assert.False(t, diags.HasError())
 	assert.Equal(t, testProxyRecordIDValue, model.ID.ValueString())
 	assert.Equal(t, testNormalizedProxyRecordDomain, model.Domain.ValueString())
-	assert.Equal(t, testProxyRecordTargetCNAME, model.TargetCNAME.ValueString())
+	assert.Equal(t, testNormalizedProxyRecordTargetCNAME, model.TargetCNAME.ValueString())
 	assert.Equal(t, testProxyRecordStatus, model.Status.ValueString())
 	assert.Equal(t, testProxyRecordCreatedAt, model.CreatedAt.ValueString())
 	assert.Equal(t, testProxyRecordUpdatedAt, model.UpdatedAt.ValueString())
 	assert.Equal(t, testProxyRecordCreatorID, model.CreatedBy.ValueInt64())
 	assert.True(t, model.Message.IsNull())
+}
+
+func TestProxyRecordMapResponseToModel_TargetCNAMEWithoutTrailingDot(t *testing.T) {
+	ops := ProxyRecordOps{}
+	resp := httpclient.ProxyRecord{
+		ID:          testProxyRecordIDValue,
+		Domain:      testNormalizedProxyRecordDomain,
+		TargetCNAME: testNormalizedProxyRecordTargetCNAME,
+		Status:      testProxyRecordStatus,
+	}
+
+	var model ProxyRecordTFModel
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+
+	assert.False(t, diags.HasError())
+	assert.Equal(t, testNormalizedProxyRecordTargetCNAME, model.TargetCNAME.ValueString())
 }
 
 func TestProxyRecordMapResponseToModel_WithMessageAndNilCreator(t *testing.T) {


### PR DESCRIPTION
Fixes #105

## What changed

`posthog_proxy_record.target_cname` is now normalized without its trailing dot before being written to state.

## Why

PostHog's API returns `target_cname` as a DNS-canonical FQDN with a trailing dot (the dot comes from the backend's `CLOUDFLARE_PROXY_BASE_CNAME` setting, concatenated in `generate_target_cname`). The provider passed it through verbatim. DNS providers like Cloudflare and Route53 store record content *without* the trailing dot, so wiring `target_cname` into a downstream `cloudflare_dns_record` produced a perpetual in-place update on every plan: Terraform refreshed `example.com` from Cloudflare while the config kept supplying `example.com.`.

Stripping the dot in `MapResponseToModel` mirrors how this resource already normalizes `domain` (lowercase, no trailing dot), and matches ecosystem convention. Users who need the dotted zone-file form can append `"."` trivially; the reverse (`trimsuffix`) is the uglier direction to leave to every consumer. The testacc DNS harness already normalizes both forms (`trimTrailingDot` / `normalizeFQDN`), so acceptance tests are unaffected.

## Migration

Clean for existing users: the next refresh silently updates state to the un-dotted form, and the phantom diff on the downstream DNS resource disappears.

## Test plan

- New unit test: `MapResponseToModel` strips the trailing dot from a dotted API response, and passes an un-dotted response through unchanged (`TestProxyRecordMapResponseToModel`, `TestProxyRecordMapResponseToModel_TargetCNAMEWithoutTrailingDot`).
- Test written first and observed failing against the old pass-through behavior.
- `make lint` clean, `make test` green (one pre-existing timing flake in `httpclient/middleware` retry-backoff tests, passes standalone), docs regenerated via `make generate`.
