### PR TITLE
feat(project_settings): expose session replay network payload capture and performance capture opt-in (#107)

### DIFF
--- a/docs/resources/project_settings.md
+++ b/docs/resources/project_settings.md
@@ -44,6 +44,16 @@ resource "posthog_project_settings" "example" {
   app_urls = ["https://app.example.com", "https://www.example.com"]
   # Authorized domains for session replay.
   recording_domains = ["https://app.example.com"]
+
+  # Capture network performance in session replay; required for the payload
+  # capture settings below to have any effect.
+  capture_performance_opt_in = true
+  # Record network request headers/bodies in session replay. Both keys must be
+  # set together. Careful: headers and bodies can contain tokens and PII.
+  session_recording_network_payload_capture_config = {
+    record_headers = true
+    record_body    = false
+  }
 }
 
 # Use the provider-level project_id and manage only a subset of settings.
@@ -60,16 +70,26 @@ resource "posthog_project_settings" "minimal" {
 - `app_urls` (List of String) The project's authorized domains — shown in PostHog settings as **Web analytics domains** (and used as the toolbar's Authorized URLs). These are the domains tracked in web analytics and where the toolbar is enabled. Maps to the team `app_urls` field. Wildcards are not allowed; order is preserved.
 - `autocapture_exceptions_opt_in` (Boolean) Whether exception autocapture is enabled.
 - `autocapture_web_vitals_opt_in` (Boolean) Whether web vitals autocapture is enabled.
+- `capture_performance_opt_in` (Boolean) Whether network performance capture is enabled for session replay. This must be `true` for `session_recording_network_payload_capture_config` to have any effect — without it, session replay does not capture network requests at all.
 - `cookieless_server_hash_mode` (Number) The cookieless server hash mode. Known values: `0` (disabled), `1` (stateless), `2` (stateful) — matching PostHog's `CookielessServerHashMode` enum. PostHog may add modes over time, so any non-negative value is accepted rather than a fixed set; consult the PostHog docs for the current options.
 - `heatmaps_opt_in` (Boolean) Whether heatmaps are enabled for web (the PostHog toolbar heatmap feature).
 - `project_id` (String) Project ID (environment) for this resource. Overrides the provider-level project_id.
 - `recording_domains` (List of String) Authorized domains for session replay. Maps to the team `recording_domains` field. Order is preserved.
+- `session_recording_network_payload_capture_config` (Attributes) Controls whether session replay records the headers and bodies of captured network requests. Only takes effect when `capture_performance_opt_in` is `true`. **Security:** recorded headers and bodies can contain sensitive data such as `Authorization` tokens, cookies, and PII from request/response payloads — enable these deliberately and review PostHog's network-capture redaction options in your SDK configuration. PostHog replaces this JSON object wholesale on update, so both `record_headers` and `record_body` must be set when the block is configured; omitting the whole block leaves the current PostHog value untouched. (see [below for nested schema](#nestedatt--session_recording_network_payload_capture_config))
 - `session_recording_opt_in` (Boolean) Whether session recording (recording user sessions) is enabled.
 - `surveys_opt_in` (Boolean) Whether surveys are enabled.
 
 ### Read-Only
 
 - `id` (String) The project (environment) ID, used as the resource identifier.
+
+<a id="nestedatt--session_recording_network_payload_capture_config"></a>
+### Nested Schema for `session_recording_network_payload_capture_config`
+
+Required:
+
+- `record_body` (Boolean) Whether to record the bodies of network requests in session replay.
+- `record_headers` (Boolean) Whether to record the headers of network requests in session replay.
 
 ## Import
 

--- a/examples/resources/posthog_project_settings/resource.tf
+++ b/examples/resources/posthog_project_settings/resource.tf
@@ -14,6 +14,16 @@ resource "posthog_project_settings" "example" {
   app_urls = ["https://app.example.com", "https://www.example.com"]
   # Authorized domains for session replay.
   recording_domains = ["https://app.example.com"]
+
+  # Capture network performance in session replay; required for the payload
+  # capture settings below to have any effect.
+  capture_performance_opt_in = true
+  # Record network request headers/bodies in session replay. Both keys must be
+  # set together. Careful: headers and bodies can contain tokens and PII.
+  session_recording_network_payload_capture_config = {
+    record_headers = true
+    record_body    = false
+  }
 }
 
 # Use the provider-level project_id and manage only a subset of settings.

--- a/internal/httpclient/environment.go
+++ b/internal/httpclient/environment.go
@@ -12,15 +12,27 @@ import (
 // Pointer types are used so that an unset field (nil) can be distinguished from a
 // field that is explicitly set to its zero value (e.g. false or 0).
 type Environment struct {
-	ID                         int64     `json:"id"`
-	HeatmapsOptIn              *bool     `json:"heatmaps_opt_in,omitempty"`
-	AutocaptureExceptionsOptIn *bool     `json:"autocapture_exceptions_opt_in,omitempty"`
-	SessionRecordingOptIn      *bool     `json:"session_recording_opt_in,omitempty"`
-	SurveysOptIn               *bool     `json:"surveys_opt_in,omitempty"`
-	CookielessServerHashMode   *int64    `json:"cookieless_server_hash_mode,omitempty"`
-	AutocaptureWebVitalsOptIn  *bool     `json:"autocapture_web_vitals_opt_in,omitempty"`
-	AppURLs                    *[]string `json:"app_urls,omitempty"`
-	RecordingDomains           *[]string `json:"recording_domains,omitempty"`
+	ID                                          int64                        `json:"id"`
+	HeatmapsOptIn                               *bool                        `json:"heatmaps_opt_in,omitempty"`
+	AutocaptureExceptionsOptIn                  *bool                        `json:"autocapture_exceptions_opt_in,omitempty"`
+	SessionRecordingOptIn                       *bool                        `json:"session_recording_opt_in,omitempty"`
+	SurveysOptIn                                *bool                        `json:"surveys_opt_in,omitempty"`
+	CookielessServerHashMode                    *int64                       `json:"cookieless_server_hash_mode,omitempty"`
+	AutocaptureWebVitalsOptIn                   *bool                        `json:"autocapture_web_vitals_opt_in,omitempty"`
+	CapturePerformanceOptIn                     *bool                        `json:"capture_performance_opt_in,omitempty"`
+	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
+	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
+	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`
+}
+
+// NetworkPayloadCaptureConfig mirrors the nullable JSON blob PostHog stores in
+// session_recording_network_payload_capture_config. Note the camelCase keys:
+// this is a JSON value consumed by the posthog-js SDK, not a REST field.
+// Inner fields are pointers so an explicit false survives serialization and a
+// missing key can be distinguished from false.
+type NetworkPayloadCaptureConfig struct {
+	RecordHeaders *bool `json:"recordHeaders,omitempty"`
+	RecordBody    *bool `json:"recordBody,omitempty"`
 }
 
 // EnvironmentSettingsRequest carries the writable subset of environment settings.
@@ -29,14 +41,16 @@ type Environment struct {
 // reusing Environment as the request body: ID has no omitempty, so reusing it would
 // serialize "id":0 into every PATCH.
 type EnvironmentSettingsRequest struct {
-	HeatmapsOptIn              *bool     `json:"heatmaps_opt_in,omitempty"`
-	AutocaptureExceptionsOptIn *bool     `json:"autocapture_exceptions_opt_in,omitempty"`
-	SessionRecordingOptIn      *bool     `json:"session_recording_opt_in,omitempty"`
-	SurveysOptIn               *bool     `json:"surveys_opt_in,omitempty"`
-	CookielessServerHashMode   *int64    `json:"cookieless_server_hash_mode,omitempty"`
-	AutocaptureWebVitalsOptIn  *bool     `json:"autocapture_web_vitals_opt_in,omitempty"`
-	AppURLs                    *[]string `json:"app_urls,omitempty"`
-	RecordingDomains           *[]string `json:"recording_domains,omitempty"`
+	HeatmapsOptIn                               *bool                        `json:"heatmaps_opt_in,omitempty"`
+	AutocaptureExceptionsOptIn                  *bool                        `json:"autocapture_exceptions_opt_in,omitempty"`
+	SessionRecordingOptIn                       *bool                        `json:"session_recording_opt_in,omitempty"`
+	SurveysOptIn                                *bool                        `json:"surveys_opt_in,omitempty"`
+	CookielessServerHashMode                    *int64                       `json:"cookieless_server_hash_mode,omitempty"`
+	AutocaptureWebVitalsOptIn                   *bool                        `json:"autocapture_web_vitals_opt_in,omitempty"`
+	CapturePerformanceOptIn                     *bool                        `json:"capture_performance_opt_in,omitempty"`
+	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
+	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
+	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`
 }
 
 func (c *PosthogClient) GetEnvironment(ctx context.Context, projectID string) (Environment, HTTPStatusCode, error) {

--- a/internal/httpclient/environment_test.go
+++ b/internal/httpclient/environment_test.go
@@ -54,6 +54,40 @@ func TestGetEnvironment(t *testing.T) {
 	assert.True(t, *env.AutocaptureWebVitalsOptIn)
 }
 
+func TestGetEnvironmentDeserializesNetworkPayloadCaptureFromRawJSON(t *testing.T) {
+	// The other tests round-trip Environment through this package's own json tags,
+	// which would agree with each other even if the tags were wrong. This handler
+	// writes a hand-written body instead (mirroring a real /api/environments/{id}/
+	// response) to pin the inbound contract: camelCase keys inside the
+	// session_recording_network_payload_capture_config blob, snake_case around it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, apiEnvironmentsPath, r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"id": 123,
+			"capture_performance_opt_in": true,
+			"session_recording_network_payload_capture_config": {"recordHeaders": true, "recordBody": false}
+		}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestPosthogClient(server)
+	env, status, err := client.GetEnvironment(context.Background(), testEnvironmentID)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, int(status))
+	require.NotNil(t, env.CapturePerformanceOptIn)
+	assert.True(t, *env.CapturePerformanceOptIn)
+	require.NotNil(t, env.SessionRecordingNetworkPayloadCaptureConfig)
+	require.NotNil(t, env.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	assert.True(t, *env.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	require.NotNil(t, env.SessionRecordingNetworkPayloadCaptureConfig.RecordBody)
+	assert.False(t, *env.SessionRecordingNetworkPayloadCaptureConfig.RecordBody, "explicit false must deserialize as a set value")
+}
+
 func TestUpdateEnvironmentSerializesOnlySetFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)

--- a/internal/resource/project_settings.go
+++ b/internal/resource/project_settings.go
@@ -6,16 +6,19 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/posthog/terraform-provider/internal/resource/core"
@@ -41,8 +44,23 @@ type ProjectSettingsModel struct {
 	SurveysOptIn               types.Bool   `tfsdk:"surveys_opt_in"`
 	CookielessServerHashMode   types.Int64  `tfsdk:"cookieless_server_hash_mode"`
 	AutocaptureWebVitalsOptIn  types.Bool   `tfsdk:"autocapture_web_vitals_opt_in"`
-	AppURLs                    types.List   `tfsdk:"app_urls"`
-	RecordingDomains           types.List   `tfsdk:"recording_domains"`
+	CapturePerformanceOptIn    types.Bool   `tfsdk:"capture_performance_opt_in"`
+	// NetworkPayloadCapture holds a NetworkPayloadCaptureModel object.
+	NetworkPayloadCapture types.Object `tfsdk:"session_recording_network_payload_capture_config"`
+	AppURLs               types.List   `tfsdk:"app_urls"`
+	RecordingDomains      types.List   `tfsdk:"recording_domains"`
+}
+
+// NetworkPayloadCaptureModel is the Terraform shape of the
+// session_recording_network_payload_capture_config JSON blob.
+type NetworkPayloadCaptureModel struct {
+	RecordHeaders types.Bool `tfsdk:"record_headers"`
+	RecordBody    types.Bool `tfsdk:"record_body"`
+}
+
+var networkPayloadCaptureAttrTypes = map[string]attr.Type{
+	"record_headers": types.BoolType,
+	"record_body":    types.BoolType,
 }
 
 func (m ProjectSettingsModel) GetID() string {
@@ -132,6 +150,34 @@ These settings live on the PostHog environment object (` + "`/api/environments/{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"capture_performance_opt_in": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether network performance capture is enabled for session replay. This must be `true` for `session_recording_network_payload_capture_config` to have any effect — without it, session replay does not capture network requests at all.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"session_recording_network_payload_capture_config": schema.SingleNestedAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "Controls whether session replay records the headers and bodies of captured network requests. Only takes effect when `capture_performance_opt_in` is `true`. " +
+					"**Security:** recorded headers and bodies can contain sensitive data such as `Authorization` tokens, cookies, and PII from request/response payloads — enable these deliberately and review PostHog's network-capture redaction options in your SDK configuration. " +
+					"PostHog replaces this JSON object wholesale on update, so both `record_headers` and `record_body` must be set when the block is configured; omitting the whole block leaves the current PostHog value untouched.",
+				Attributes: map[string]schema.Attribute{
+					"record_headers": schema.BoolAttribute{
+						Required:            true,
+						MarkdownDescription: "Whether to record the headers of network requests in session replay.",
+					},
+					"record_body": schema.BoolAttribute{
+						Required:            true,
+						MarkdownDescription: "Whether to record the bodies of network requests in session replay.",
+					},
+				},
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"app_urls": schema.ListAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -162,7 +208,22 @@ func (o ProjectSettingsOps) BuildCreateRequest(ctx context.Context, model Projec
 		SessionRecordingOptIn:      util.BoolPtrFromValue(model.SessionRecordingOptIn),
 		SurveysOptIn:               util.BoolPtrFromValue(model.SurveysOptIn),
 		AutocaptureWebVitalsOptIn:  util.BoolPtrFromValue(model.AutocaptureWebVitalsOptIn),
+		CapturePerformanceOptIn:    util.BoolPtrFromValue(model.CapturePerformanceOptIn),
 		CookielessServerHashMode:   util.Int64PtrFromValue(model.CookielessServerHashMode),
+	}
+
+	// An unset block stays nil so the PATCH omits the field entirely (leave
+	// untouched). When set, both children are sent: PostHog replaces the whole
+	// JSON blob, so a partial object would wipe the missing key server-side.
+	if !model.NetworkPayloadCapture.IsNull() && !model.NetworkPayloadCapture.IsUnknown() {
+		var cfg NetworkPayloadCaptureModel
+		diags.Append(model.NetworkPayloadCapture.As(ctx, &cfg, basetypes.ObjectAsOptions{})...)
+		if !diags.HasError() {
+			req.SessionRecordingNetworkPayloadCaptureConfig = &httpclient.NetworkPayloadCaptureConfig{
+				RecordHeaders: util.BoolPtrFromValue(cfg.RecordHeaders),
+				RecordBody:    util.BoolPtrFromValue(cfg.RecordBody),
+			}
+		}
 	}
 
 	appURLs, d := util.StringListToSlicePtr(ctx, model.AppURLs)
@@ -208,6 +269,12 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	if util.Int64Diverged(model.CookielessServerHashMode, resp.CookielessServerHashMode) {
 		ignored = append(ignored, "cookieless_server_hash_mode")
 	}
+	if util.BoolDiverged(model.CapturePerformanceOptIn, resp.CapturePerformanceOptIn) {
+		ignored = append(ignored, "capture_performance_opt_in")
+	}
+	if networkPayloadCaptureDiverged(ctx, model.NetworkPayloadCapture, resp.SessionRecordingNetworkPayloadCaptureConfig) {
+		ignored = append(ignored, "session_recording_network_payload_capture_config")
+	}
 	if len(ignored) > 0 {
 		diags.AddWarning(
 			"PostHog did not apply some configured settings",
@@ -225,7 +292,21 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	model.SessionRecordingOptIn = core.PtrToBool(resp.SessionRecordingOptIn)
 	model.SurveysOptIn = core.PtrToBool(resp.SurveysOptIn)
 	model.AutocaptureWebVitalsOptIn = core.PtrToBool(resp.AutocaptureWebVitalsOptIn)
+	model.CapturePerformanceOptIn = core.PtrToBool(resp.CapturePerformanceOptIn)
 	model.CookielessServerHashMode = util.PtrToInt64(resp.CookielessServerHashMode)
+
+	if resp.SessionRecordingNetworkPayloadCaptureConfig == nil {
+		// PostHog stores null until the setting is first written; map that to a
+		// null object rather than an object of null bools.
+		model.NetworkPayloadCapture = types.ObjectNull(networkPayloadCaptureAttrTypes)
+	} else {
+		obj, d := types.ObjectValueFrom(ctx, networkPayloadCaptureAttrTypes, NetworkPayloadCaptureModel{
+			RecordHeaders: core.PtrToBool(resp.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders),
+			RecordBody:    core.PtrToBool(resp.SessionRecordingNetworkPayloadCaptureConfig.RecordBody),
+		})
+		diags.Append(d...)
+		model.NetworkPayloadCapture = obj
+	}
 
 	appURLs, d := util.StringSlicePtrToList(ctx, resp.AppURLs)
 	diags.Append(d...)
@@ -236,6 +317,25 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	model.RecordingDomains = recordingDomains
 
 	return diags
+}
+
+// networkPayloadCaptureDiverged reports whether a configured (non-null,
+// non-unknown) payload-capture object differs from what the server returned.
+// It is the object counterpart of util.BoolDiverged: unconfigured objects
+// never diverge, a nil server value counts as divergent.
+func networkPayloadCaptureDiverged(ctx context.Context, configured types.Object, server *httpclient.NetworkPayloadCaptureConfig) bool {
+	if configured.IsNull() || configured.IsUnknown() {
+		return false
+	}
+	var cfg NetworkPayloadCaptureModel
+	if configured.As(ctx, &cfg, basetypes.ObjectAsOptions{}).HasError() {
+		return false
+	}
+	if server == nil {
+		return true
+	}
+	return util.BoolDiverged(cfg.RecordHeaders, server.RecordHeaders) ||
+		util.BoolDiverged(cfg.RecordBody, server.RecordBody)
 }
 
 func (o ProjectSettingsOps) Create(ctx context.Context, client httpclient.PosthogClient, model ProjectSettingsModel, req httpclient.EnvironmentSettingsRequest) (httpclient.Environment, error) {

--- a/internal/resource/project_settings.go
+++ b/internal/resource/project_settings.go
@@ -224,6 +224,19 @@ func (o ProjectSettingsOps) BuildCreateRequest(ctx context.Context, model Projec
 				RecordBody:    util.BoolPtrFromValue(cfg.RecordBody),
 			}
 		}
+		// ValueBool is false for null and unknown too, which is the intent:
+		// warn unless performance capture is known to be enabled in this plan
+		// (an unset attribute carries the last-read server value, so users who
+		// enabled it outside Terraform are not nagged after the first refresh).
+		if !model.CapturePerformanceOptIn.ValueBool() {
+			diags.AddWarning(
+				"session_recording_network_payload_capture_config has no effect without capture_performance_opt_in",
+				"Session replay only captures network requests when network performance capture is enabled, "+
+					"so the configured payload capture settings will do nothing until capture_performance_opt_in is true. "+
+					"Set capture_performance_opt_in = true in this resource, or ignore this warning if network capture "+
+					"is already enabled for the project outside Terraform.",
+			)
+		}
 	}
 
 	appURLs, d := util.StringListToSlicePtr(ctx, model.AppURLs)
@@ -322,14 +335,21 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 // networkPayloadCaptureDiverged reports whether a configured (non-null,
 // non-unknown) payload-capture object differs from what the server returned.
 // It is the object counterpart of util.BoolDiverged: unconfigured objects
-// never diverge, a nil server value counts as divergent.
+// never diverge; a nil server value or an unparseable configured value counts
+// as divergent.
 func networkPayloadCaptureDiverged(ctx context.Context, configured types.Object, server *httpclient.NetworkPayloadCaptureConfig) bool {
 	if configured.IsNull() || configured.IsUnknown() {
 		return false
 	}
 	var cfg NetworkPayloadCaptureModel
-	if configured.As(ctx, &cfg, basetypes.ObjectAsOptions{}).HasError() {
-		return false
+	if d := configured.As(ctx, &cfg, basetypes.ObjectAsOptions{}); d.HasError() {
+		// Unreachable for a schema-derived object, but if it ever fires the
+		// attribute must be named in the divergence warning rather than
+		// vanishing into the generic "inconsistent result after apply" error.
+		tflog.Error(ctx, "failed to parse configured session_recording_network_payload_capture_config; treating as diverged", map[string]any{
+			"diagnostics": fmt.Sprintf("%v", d),
+		})
+		return true
 	}
 	if server == nil {
 		return true

--- a/internal/resource/project_settings_test.go
+++ b/internal/resource/project_settings_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/posthog/terraform-provider/internal/httpclient"
@@ -162,6 +163,54 @@ func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureExplicitFalse(t 
 // TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureAbsent guards the
 // leave-untouched contract: an unset block must be omitted from the PATCH body
 // entirely, not sent as null or {} (the API replaces the whole JSON blob).
+// TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureWarnsWithoutPerformanceCapture
+// guards the no-op warning: payload capture only takes effect when network
+// performance capture is enabled, so configuring the block without a known-true
+// capture_performance_opt_in must warn (and only then).
+func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureWarnsWithoutPerformanceCapture(t *testing.T) {
+	ops := ProjectSettingsOps{}
+
+	t.Run("warns when capture_performance_opt_in is unset", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, false)
+
+		_, diags := ops.BuildCreateRequest(context.Background(), model)
+
+		assert.False(t, diags.HasError())
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Summary(), "capture_performance_opt_in")
+	})
+
+	t.Run("warns when capture_performance_opt_in is false", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.CapturePerformanceOptIn = types.BoolValue(false)
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, false)
+
+		_, diags := ops.BuildCreateRequest(context.Background(), model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+	})
+
+	t.Run("no warning when capture_performance_opt_in is true", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.CapturePerformanceOptIn = types.BoolValue(true)
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, false)
+
+		_, diags := ops.BuildCreateRequest(context.Background(), model)
+
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+
+	t.Run("no warning when the block is not configured", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.CapturePerformanceOptIn = types.BoolValue(false)
+
+		_, diags := ops.BuildCreateRequest(context.Background(), model)
+
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
+}
+
 func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureAbsent(t *testing.T) {
 	ops := ProjectSettingsOps{}
 	model := newProjectSettingsModel()
@@ -334,6 +383,27 @@ func TestProjectSettingsMapResponseToModel_DivergenceWarning(t *testing.T) {
 
 		require.Equal(t, 1, diags.WarningsCount())
 		assert.Contains(t, diags.Warnings()[0].Detail(), "capture_performance_opt_in")
+	})
+
+	t.Run("unparseable configured object counts as diverged", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		// Wrong child type: As() into NetworkPayloadCaptureModel must fail, and
+		// the attribute must still be named in the warning (not suppressed).
+		model.NetworkPayloadCapture = types.ObjectValueMust(
+			map[string]attr.Type{"record_headers": types.StringType, "record_body": types.BoolType},
+			map[string]attr.Value{"record_headers": types.StringValue("not-a-bool"), "record_body": types.BoolValue(true)},
+		)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{
+			ID: 123,
+			SessionRecordingNetworkPayloadCaptureConfig: &httpclient.NetworkPayloadCaptureConfig{
+				RecordHeaders: util.BoolPtr(true),
+				RecordBody:    util.BoolPtr(true),
+			},
+		}, &model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Detail(), "session_recording_network_payload_capture_config")
 	})
 
 	t.Run("no warning when server matches", func(t *testing.T) {

--- a/internal/resource/project_settings_test.go
+++ b/internal/resource/project_settings_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/posthog/terraform-provider/internal/util"
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,76 @@ func TestProjectSettingsBuildCreateRequest_EmptyListClears(t *testing.T) {
 	assert.Empty(t, *req.RecordingDomains)
 }
 
+func networkPayloadCaptureObject(t *testing.T, headers, body bool) types.Object {
+	t.Helper()
+	obj, d := types.ObjectValueFrom(context.Background(), networkPayloadCaptureAttrTypes, NetworkPayloadCaptureModel{
+		RecordHeaders: types.BoolValue(headers),
+		RecordBody:    types.BoolValue(body),
+	})
+	require.False(t, d.HasError())
+	return obj
+}
+
+func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureSet(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.CapturePerformanceOptIn = types.BoolValue(true)
+	model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, true)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, req.CapturePerformanceOptIn)
+	assert.True(t, *req.CapturePerformanceOptIn)
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig)
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	assert.True(t, *req.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig.RecordBody)
+	assert.True(t, *req.SessionRecordingNetworkPayloadCaptureConfig.RecordBody)
+}
+
+// TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureExplicitFalse guards
+// the zero-value path: explicit false on both children must survive into the
+// serialized PATCH body (camelCase keys), not be dropped by omitempty.
+func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureExplicitFalse(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.NetworkPayloadCapture = networkPayloadCaptureObject(t, false, false)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig)
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	assert.False(t, *req.SessionRecordingNetworkPayloadCaptureConfig.RecordHeaders)
+	require.NotNil(t, req.SessionRecordingNetworkPayloadCaptureConfig.RecordBody)
+	assert.False(t, *req.SessionRecordingNetworkPayloadCaptureConfig.RecordBody)
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"session_recording_network_payload_capture_config":{"recordHeaders":false,"recordBody":false}`)
+}
+
+// TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureAbsent guards the
+// leave-untouched contract: an unset block must be omitted from the PATCH body
+// entirely, not sent as null or {} (the API replaces the whole JSON blob).
+func TestProjectSettingsBuildCreateRequest_NetworkPayloadCaptureAbsent(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.HeatmapsOptIn = types.BoolValue(true)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	assert.Nil(t, req.SessionRecordingNetworkPayloadCaptureConfig)
+	assert.Nil(t, req.CapturePerformanceOptIn)
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "session_recording_network_payload_capture_config")
+	assert.NotContains(t, string(body), "capture_performance_opt_in")
+}
+
 func TestProjectSettingsBuildUpdateRequest(t *testing.T) {
 	ops := ProjectSettingsOps{}
 	plan := newProjectSettingsModel()
@@ -179,6 +250,108 @@ func TestProjectSettingsMapResponseToModel_NilFieldsBecomeNull(t *testing.T) {
 	assert.True(t, model.SurveysOptIn.IsNull())
 	assert.True(t, model.CookielessServerHashMode.IsNull())
 	assert.True(t, model.AutocaptureWebVitalsOptIn.IsNull())
+}
+
+func TestProjectSettingsMapResponseToModel_NetworkPayloadCapturePresent(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	resp := httpclient.Environment{
+		ID:                      123,
+		CapturePerformanceOptIn: util.BoolPtr(true),
+		SessionRecordingNetworkPayloadCaptureConfig: &httpclient.NetworkPayloadCaptureConfig{
+			RecordHeaders: util.BoolPtr(true),
+			RecordBody:    util.BoolPtr(false),
+		},
+	}
+
+	model := newProjectSettingsModel()
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+
+	assert.False(t, diags.HasError())
+	assert.True(t, model.CapturePerformanceOptIn.ValueBool())
+	require.False(t, model.NetworkPayloadCapture.IsNull())
+	var cfg NetworkPayloadCaptureModel
+	require.False(t, model.NetworkPayloadCapture.As(context.Background(), &cfg, basetypes.ObjectAsOptions{}).HasError())
+	assert.True(t, cfg.RecordHeaders.ValueBool())
+	require.False(t, cfg.RecordBody.IsNull(), "explicit false must map to a known value, not null")
+	assert.False(t, cfg.RecordBody.ValueBool())
+}
+
+// TestProjectSettingsMapResponseToModel_NetworkPayloadCaptureNull covers the
+// server default: PostHog stores null until the setting is first written, and
+// that must map to a null object (not an object of null bools).
+func TestProjectSettingsMapResponseToModel_NetworkPayloadCaptureNull(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	resp := httpclient.Environment{ID: 123}
+
+	model := newProjectSettingsModel()
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+
+	assert.False(t, diags.HasError())
+	assert.True(t, model.CapturePerformanceOptIn.IsNull())
+	assert.True(t, model.NetworkPayloadCapture.IsNull())
+}
+
+// TestProjectSettingsMapResponseToModel_DivergenceWarning verifies the
+// plan-gated warning names the new attributes when PostHog returns different
+// values than the ones the user configured.
+func TestProjectSettingsMapResponseToModel_DivergenceWarning(t *testing.T) {
+	ops := ProjectSettingsOps{}
+
+	t.Run("network payload capture ignored (server null)", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, false)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{ID: 123}, &model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Detail(), "session_recording_network_payload_capture_config")
+	})
+
+	t.Run("network payload capture child value diverged", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, true)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{
+			ID: 123,
+			SessionRecordingNetworkPayloadCaptureConfig: &httpclient.NetworkPayloadCaptureConfig{
+				RecordHeaders: util.BoolPtr(true),
+				RecordBody:    util.BoolPtr(false),
+			},
+		}, &model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Detail(), "session_recording_network_payload_capture_config")
+	})
+
+	t.Run("capture_performance_opt_in diverged", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.CapturePerformanceOptIn = types.BoolValue(true)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{
+			ID:                      123,
+			CapturePerformanceOptIn: util.BoolPtr(false),
+		}, &model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Detail(), "capture_performance_opt_in")
+	})
+
+	t.Run("no warning when server matches", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.CapturePerformanceOptIn = types.BoolValue(true)
+		model.NetworkPayloadCapture = networkPayloadCaptureObject(t, true, false)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{
+			ID:                      123,
+			CapturePerformanceOptIn: util.BoolPtr(true),
+			SessionRecordingNetworkPayloadCaptureConfig: &httpclient.NetworkPayloadCaptureConfig{
+				RecordHeaders: util.BoolPtr(true),
+				RecordBody:    util.BoolPtr(false),
+			},
+		}, &model)
+
+		assert.Equal(t, 0, diags.WarningsCount())
+	})
 }
 
 func TestProjectSettingsDeleteIsNoOp(t *testing.T) {

--- a/testacc/project_settings_test.go
+++ b/testacc/project_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -160,6 +161,51 @@ func TestProjectSettings_Domains(t *testing.T) {
 	})
 }
 
+// TestProjectSettings_NetworkPayloadCapture exercises capture_performance_opt_in
+// and the session_recording_network_payload_capture_config nested object
+// end-to-end: apply, read-back, update (flip record_body), and import. It also
+// verifies the required-children contract: a partial block must fail validation
+// before any API call, since PostHog replaces the whole JSON blob on PATCH.
+func TestProjectSettings_NetworkPayloadCapture(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	projectID := getProjectID()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccProjectSettingsConfigNetworkPayloadCapturePartial(),
+				ExpectError: regexp.MustCompile(`record_body`),
+			},
+			{
+				Config: testAccProjectSettingsConfigNetworkPayloadCapture(true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "capture_performance_opt_in", "true"),
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "session_recording_network_payload_capture_config.record_headers", "true"),
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "session_recording_network_payload_capture_config.record_body", "false"),
+				),
+			},
+			{
+				Config: testAccProjectSettingsConfigNetworkPayloadCapture(true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "capture_performance_opt_in", "true"),
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "session_recording_network_payload_capture_config.record_headers", "true"),
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "session_recording_network_payload_capture_config.record_body", "true"),
+				),
+			},
+			{
+				ResourceName:            "posthog_project_settings.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           projectID,
+				ImportStateVerifyIgnore: []string{"project_id"},
+			},
+		},
+	})
+}
+
 func testAccProjectSettingsConfig(heatmaps, sessionRecording, surveys bool) string {
 	return fmt.Sprintf(`
 provider "posthog" {}
@@ -194,6 +240,36 @@ provider "posthog" {}
 resource "posthog_project_settings" "test" {
   app_urls          = ["https://app.example.com", "https://www.example.com"]
   recording_domains = ["https://app.example.com"]
+}
+`
+}
+
+func testAccProjectSettingsConfigNetworkPayloadCapture(recordHeaders, recordBody bool) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_project_settings" "test" {
+  session_recording_opt_in   = true
+  capture_performance_opt_in = true
+
+  session_recording_network_payload_capture_config = {
+    record_headers = %t
+    record_body    = %t
+  }
+}
+`, recordHeaders, recordBody)
+}
+
+// A partial payload-capture block: must fail config validation (record_body is
+// required) rather than PATCH a partial object that would wipe the other key.
+func testAccProjectSettingsConfigNetworkPayloadCapturePartial() string {
+	return `
+provider "posthog" {}
+
+resource "posthog_project_settings" "test" {
+  session_recording_network_payload_capture_config = {
+    record_headers = true
+  }
 }
 `
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/doc.go
@@ -1,0 +1,5 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package objectplanmodifier provides plan modifiers for types.Object attributes.
+package objectplanmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace.go
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Object {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.ObjectRequest, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Object {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyObject implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_configured.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Object {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.ObjectRequest, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_func.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.ObjectRequest, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_non_null_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_non_null_state_for_unknown.go
@@ -1,0 +1,54 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseNonNullStateForUnknown returns a plan modifier that copies a known, non-null, prior state
+// value into the planned value. Use this when it is known that an unconfigured value will remain the
+// same after the attribute is updated to a non-null value.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the non-null prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+//
+// This plan modifier can be a useful alternative to [UseStateForUnknown] when the attribute is
+// a child of a nested attribute that can be null after the resource is created.
+func UseNonNullStateForUnknown() planmodifier.Object {
+	return useNonNullStateForUnknown{}
+}
+
+type useNonNullStateForUnknown struct{}
+
+func (m useNonNullStateForUnknown) Description(_ context.Context) string {
+	return "Once set to a non-null value, the value of this attribute in state will not change."
+}
+
+func (m useNonNullStateForUnknown) MarkdownDescription(_ context.Context) string {
+	return "Once set to a non-null value, the value of this attribute in state will not change."
+}
+
+func (m useNonNullStateForUnknown) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Do nothing if the state value is null.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+//
+// Null is also a known value in Terraform and will be copied to the planned value
+// by this plan modifier. For use-cases like a child attribute of a nested attribute or
+// if null is desired to be marked as unknown in the case of an update, use [UseNonNullStateForUnknown].
+func UseStateForUnknown() planmodifier.Object {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyObject implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -172,6 +172,7 @@ github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults
 github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier
+github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier
 github.com/hashicorp/terraform-plugin-framework/schema/validator


### PR DESCRIPTION
## What

Exposes PostHog's session replay network payload capture settings on `posthog_project_settings`:

- `session_recording_network_payload_capture_config` — a nested object (`record_headers`, `record_body`) mapping to the nullable JSON field of the same name on `PATCH /api/environments/{id}/` (camelCase `recordHeaders`/`recordBody` keys inside the JSON blob, matching what posthog-js consumes).
- `capture_performance_opt_in` — the flat bool that enables network performance capture in session replay.

Research and proposal by @cramt — thanks! Closes #107.

## Why

These toggles control whether session replay records network request headers and bodies. They are security-sensitive (headers can carry `Authorization` tokens, bodies can carry PII), so teams want them under Terraform control and code review rather than clickops. The attribute docs call out the security implications explicitly.

## Design decisions

- **Both nested children are required when the block is set.** PostHog replaces the whole JSON object on PATCH (verified against the API serializer: it accepts only `recordHeaders`/`recordBody` keys and stores the dict as-is), so a partial object would silently wipe the omitted key server-side. The framework enforces this at plan time; a partial block never reaches the API. Omitting the whole block keeps the resource's existing leave-untouched contract (field omitted from the PATCH body).
- **`capture_performance_opt_in` is bundled in this PR** because `recordHeaders`/`recordBody` only take effect when network capture is enabled — without it the payload capture setting is inert. The docs cross-reference the dependency.
- Explicit `false` values survive serialization (pointer fields inside the JSON blob), server `null` maps to a null object in state, and both new attributes participate in the existing plan-gated divergence warning that names settings PostHog silently ignored.

## Test plan

- Unit tests (`internal/resource/project_settings_test.go`): request building with the block set (both true / both false — asserts explicit `false` serializes into the JSON body), block absent (field omitted from PATCH), response mapping (object present / server null), and divergence warnings for both new attributes (server null, child value diverged, and the no-warning happy path).
- Acceptance test (`testacc/project_settings_test.go`, `TestProjectSettings_NetworkPayloadCapture`): plan-time rejection of a partial block, apply with `record_headers = true, record_body = false`, read-back, update flipping `record_body`, and import verification.
- Gates run locally: `make fmt`, `make lint` (0 issues), `make test`, `make build`, `make generate` (docs committed).
- Acceptance verified against a live local PostHog instance (2026-07-14): all 6 `TestProjectSettings_*` acceptance tests pass, including `TestProjectSettings_NetworkPayloadCapture` (partial-block plan-time rejection, apply, read-back, `record_body` flip, import). The earlier 401 credential issue was resolved with a fresh personal API key; the API contract had additionally been verified against the PostHog source (`posthog/api/team.py`: both fields writable on `/api/environments/{id}/`, `validate_session_recording_network_payload_capture_config` accepts exactly the `recordHeaders`/`recordBody` keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

