### PR TITLE
fix(feature_flag): compare filters as normalized JSON to stop perpetual diff

### DIFF
--- a/docs/resources/feature_flag.md
+++ b/docs/resources/feature_flag.md
@@ -24,7 +24,7 @@ PostHog Feature Flag resource
 - `active` (Boolean) Whether the feature flag is active
 - `deleted` (Boolean) Whether the feature flag is soft-deleted. Terraform will restore soft-deleted flags on apply.
 - `ensure_experience_continuity` (Boolean) Whether to persist the flag across authentication steps (PostHog's UI labels this as 'Persist flag across authentication steps'). Flags with experience continuity enabled cannot be evaluated by server-side local evaluation; set this to false for flags that must be evaluated locally.
-- `filters` (String) Feature flag filters as JSON
+- `filters` (String) Feature flag filters as JSON. Compared semantically, so key ordering and whitespace differences from the PostHog API do not produce a diff.
 - `name` (String) Feature flag name/description (PostHog's UI labels this as 'Description'). The API does not expose a separate dedicated description field for feature flags.
 - `project_id` (String) Project ID (environment) for this resource. Overrides the provider-level project_id.
 - `rollout_percentage` (Number) Rollout percentage (0-100)

--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -27,14 +28,14 @@ func NewFeatureFlag() resource.Resource {
 type FeatureFlagTFModel struct {
 	core.BaseInt64Identifiable
 	core.BaseProjectID
-	Key                        types.String `tfsdk:"key"`
-	Name                       types.String `tfsdk:"name"`
-	Active                     types.Bool   `tfsdk:"active"`
-	Filters                    types.String `tfsdk:"filters"`
-	RolloutPercentage          types.Int64  `tfsdk:"rollout_percentage"`
-	Tags                       types.Set    `tfsdk:"tags"`
-	Deleted                    types.Bool   `tfsdk:"deleted"`
-	EnsureExperienceContinuity types.Bool   `tfsdk:"ensure_experience_continuity"`
+	Key                        types.String         `tfsdk:"key"`
+	Name                       types.String         `tfsdk:"name"`
+	Active                     types.Bool           `tfsdk:"active"`
+	Filters                    jsontypes.Normalized `tfsdk:"filters"`
+	RolloutPercentage          types.Int64          `tfsdk:"rollout_percentage"`
+	Tags                       types.Set            `tfsdk:"tags"`
+	Deleted                    types.Bool           `tfsdk:"deleted"`
+	EnsureExperienceContinuity types.Bool           `tfsdk:"ensure_experience_continuity"`
 }
 
 type FeatureFlagOps struct{}
@@ -84,9 +85,10 @@ func (o FeatureFlagOps) Schema() schema.Schema {
 				},
 			},
 			"filters": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "Feature flag filters as JSON",
+				MarkdownDescription: "Feature flag filters as JSON. Compared semantically, so key ordering and whitespace differences from the PostHog API do not produce a diff.",
 			},
 			"rollout_percentage": schema.Int64Attribute{
 				Optional:            true,
@@ -272,10 +274,10 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	if len(resp.Filters) > 0 {
 		normalizedFilters, err := normalizeJSONForState(resp.Filters, model.Filters.ValueString())
 		if err == nil {
-			model.Filters = types.StringValue(normalizedFilters)
+			model.Filters = jsontypes.NewNormalizedValue(normalizedFilters)
 		}
 	} else {
-		model.Filters = types.StringNull()
+		model.Filters = jsontypes.NewNormalizedNull()
 	}
 
 	model.RolloutPercentage = extractRolloutPercentage(resp)

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,7 @@ import (
 func TestFeatureFlagMapResponseToModel_NormalizesServerOnlyFilterFields(t *testing.T) {
 	ops := FeatureFlagOps{}
 	model := FeatureFlagTFModel{
-		Filters: types.StringValue(`{"groups":[{"rollout_percentage":0}]}`),
+		Filters: jsontypes.NewNormalizedValue(`{"groups":[{"rollout_percentage":0}]}`),
 	}
 
 	resp := httpclient.FeatureFlag{
@@ -34,6 +35,50 @@ func TestFeatureFlagMapResponseToModel_NormalizesServerOnlyFilterFields(t *testi
 	require.False(t, diags.HasError(), diags.Errors())
 	assert.Equal(t, `{"groups":[{"rollout_percentage":0}]}`, model.Filters.ValueString())
 	assert.Equal(t, int64(0), model.RolloutPercentage.ValueInt64())
+}
+
+// TestFeatureFlagMapResponseToModel_NoPerpetualDiffOnKeyOrder reproduces issue #111:
+// PostHog's API returns filters JSON with alphabetically-sorted object keys, while the
+// user's config uses a natural (non-alphabetical) key order. A byte-for-byte comparison
+// of config vs. state therefore reports an endless diff. Using jsontypes.Normalized makes
+// the framework compare the two semantically, so equivalent JSON no longer drifts.
+func TestFeatureFlagMapResponseToModel_NoPerpetualDiffOnKeyOrder(t *testing.T) {
+	ops := FeatureFlagOps{}
+
+	// User config: property object keys in a natural (non-alphabetical) order.
+	configJSON := `{"groups":[{"properties":[{"key":"email","type":"person","operator":"icontains","value":"@posthog.com"}]}]}`
+	model := FeatureFlagTFModel{
+		Filters: jsontypes.NewNormalizedValue(configJSON),
+	}
+
+	// API returns the same data but with alphabetically-sorted keys.
+	resp := httpclient.FeatureFlag{
+		ID:  1,
+		Key: "my_flag",
+		Filters: map[string]interface{}{
+			"groups": []interface{}{
+				map[string]interface{}{
+					"properties": []interface{}{
+						map[string]interface{}{
+							"key":      "email",
+							"operator": "icontains",
+							"type":     "person",
+							"value":    "@posthog.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+	require.False(t, diags.HasError(), diags.Errors())
+
+	// The stored state must be semantically equal to the user's config; otherwise
+	// Terraform reports a perpetual diff even though nothing changed.
+	eq, d := model.Filters.StringSemanticEquals(context.Background(), jsontypes.NewNormalizedValue(configJSON))
+	require.False(t, d.HasError(), d.Errors())
+	assert.True(t, eq, "filters state must be semantically equal to config to avoid a perpetual diff")
 }
 
 func TestFeatureFlagBuildCreateRequestSetsEnsureExperienceContinuity(t *testing.T) {

--- a/testacc/feature_flag_test.go
+++ b/testacc/feature_flag_test.go
@@ -114,6 +114,38 @@ func TestFeatureFlag_Filters(t *testing.T) {
 	})
 }
 
+// TestFeatureFlag_FiltersNoPerpetualDiff is the end-to-end regression test for issue #111.
+// It configures filters as a RAW JSON string whose object keys are in a natural,
+// non-alphabetical order (key, type, operator, value) — unlike jsonencode, which sorts
+// keys. PostHog's API returns the same filters with alphabetically-sorted keys, so with
+// the old types.String attribute the second (PlanOnly) step would report a perpetual diff.
+// With jsontypes.Normalized the two are compared semantically, so the re-plan is empty.
+func TestFeatureFlag_FiltersNoPerpetualDiff(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rKey := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFeatureFlagRawFilters(rKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_feature_flag.test", "key", rKey),
+					resource.TestCheckResourceAttrSet("posthog_feature_flag.test", "filters"),
+				),
+			},
+			{
+				// Re-plan with the identical raw, non-alphabetical config. A non-empty plan
+				// here is exactly the issue #111 perpetual diff; PlanOnly fails on any change.
+				Config:   testAccFeatureFlagRawFilters(rKey),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestFeatureFlag_FiltersWithRollout tests filters JSON with embedded rollout_percentage.
 func TestFeatureFlag_FiltersWithRollout(t *testing.T) {
 	skipIfNotAcceptance(t)
@@ -435,6 +467,23 @@ resource "posthog_feature_flag" "test" {
       rollout_percentage = 100
     }]
   })
+}
+`, key)
+}
+
+// testAccFeatureFlagRawFilters builds a config whose filters is a RAW JSON string (not
+// jsonencode) with object keys deliberately in non-alphabetical order, to reproduce the
+// key-ordering drift from issue #111.
+func testAccFeatureFlagRawFilters(key string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_feature_flag" "test" {
+  key    = %q
+  name   = "Raw Filters No Perpetual Diff"
+  active = true
+
+  filters = "{\"groups\":[{\"properties\":[{\"key\":\"email\",\"type\":\"person\",\"operator\":\"exact\",\"value\":[\"test@example.com\"]}],\"rollout_percentage\":100}]}"
 }
 `, key)
 }


### PR DESCRIPTION
## What & why

Fixes #111 — `posthog_feature_flag` showed a **perpetual diff on `filters`** after every apply.

**Root cause:** `filters` was a plain `types.String`, so Terraform compared the user's config JSON **byte-for-byte** against the value in state. `MapResponseToModel` canonicalizes the state (Go's `json.Marshal` sorts object keys alphabetically, matching PostHog's API), but it can't touch the *config* value — a user whose config keys aren't alphabetical (e.g. a raw `{"key":…,"type":…,"operator":…,"value":…}` string) drifts on every `plan`.

**Fix:** type `filters` as `jsontypes.Normalized`, which does **semantic JSON equality** (ignores key order and whitespace). This mirrors the existing `posthog_dashboard` `layouts_json` precedent exactly (`internal/resource/dashboard_layout.go`). `normalizeJSONForState` is **kept** — it strips server-only fields the user never specified, which semantic equality alone does not cover.

## Changes

- `internal/resource/feature_flag.go` — `Filters` → `jsontypes.Normalized`; schema `CustomType: jsontypes.NormalizedType{}`; state mapping via `NewNormalizedValue`/`NewNormalizedNull`.
- `internal/resource/feature_flag_test.go` — new unit test asserting state is semantically equal to differently-key-ordered config (fails to compile if the fix is reverted, so it's not vacuous); existing test updated for the new type.
- `testacc/feature_flag_test.go` — new acceptance test `TestFeatureFlag_FiltersNoPerpetualDiff` using a **raw, non-alphabetically-keyed** `filters` string plus a `PlanOnly` re-plan step that fails on any perpetual diff. (The existing filter tests use `jsonencode`, which sorts keys, so they can't reproduce #111.)
- `docs/resources/feature_flag.md` — regenerated via `tfplugindocs`.

## Test plan

- [x] `go build ./...`, `go vet ./...` — pass
- [x] `go test ./internal/...` — pass (incl. new `TestFeatureFlagMapResponseToModel_NoPerpetualDiffOnKeyOrder`)
- [x] `gofmt` clean; docs regenerated
- [ ] **Live acceptance run pending** — the local dev instance is up (`/_health` = 200) but the API key baked into `playground/provider.tf` is stale (401). Once refreshed:
  ```
  TF_ACC=1 go test ./testacc/ -run 'TestFeatureFlag_Filters' -v -timeout 15m
  ```

Draft until the live acceptance run is attached.
