### PR TITLE
fix(feature_flag): preserve remote filter drift

### DIFF
--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -272,7 +272,7 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 
 	// Set filters if present
 	if len(resp.Filters) > 0 {
-		normalizedFilters, err := normalizeJSONForState(resp.Filters, model.Filters.ValueString())
+		normalizedFilters, err := normalizeFeatureFlagFiltersForState(resp.Filters, model.Filters.ValueString())
 		if err == nil {
 			model.Filters = jsontypes.NewNormalizedValue(normalizedFilters)
 		}
@@ -292,6 +292,63 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	model.Deleted = types.BoolValue(deleted)
 
 	return diags
+}
+
+// normalizeFeatureFlagFiltersForState keeps meaningful API fields so Terraform
+// can detect remote filter changes, while omitting unconfigured empty defaults
+// that PostHog adds to the response.
+func normalizeFeatureFlagFiltersForState(apiData map[string]interface{}, stateJSON string) (string, error) {
+	var stateData interface{}
+	if err := json.Unmarshal([]byte(stateJSON), &stateData); err != nil {
+		stateData = nil
+	}
+
+	return marshalJSON(normalizeFeatureFlagFilterValue(stateData, apiData))
+}
+
+func normalizeFeatureFlagFilterValue(stateData, apiData interface{}) interface{} {
+	switch apiValue := apiData.(type) {
+	case map[string]interface{}:
+		stateMap, _ := stateData.(map[string]interface{})
+		result := make(map[string]interface{})
+		for key, apiFieldValue := range apiValue {
+			stateFieldValue, configured := stateMap[key]
+			normalized := normalizeFeatureFlagFilterValue(stateFieldValue, apiFieldValue)
+			if !configured && isEmptyFeatureFlagFilterValue(normalized) {
+				continue
+			}
+			result[key] = normalized
+		}
+		return result
+
+	case []interface{}:
+		stateSlice, _ := stateData.([]interface{})
+		result := make([]interface{}, len(apiValue))
+		for i, apiItem := range apiValue {
+			var stateItem interface{}
+			if i < len(stateSlice) {
+				stateItem = stateSlice[i]
+			}
+			result[i] = normalizeFeatureFlagFilterValue(stateItem, apiItem)
+		}
+		return result
+
+	default:
+		return apiData
+	}
+}
+
+func isEmptyFeatureFlagFilterValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case map[string]interface{}:
+		return len(typed) == 0
+	case []interface{}:
+		return len(typed) == 0
+	default:
+		return false
+	}
 }
 
 func (o FeatureFlagOps) Create(ctx context.Context, client httpclient.PosthogClient, model FeatureFlagTFModel, req httpclient.FeatureFlagRequest) (httpclient.FeatureFlag, error) {

--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -294,9 +294,21 @@ func (o FeatureFlagOps) MapResponseToModel(ctx context.Context, resp httpclient.
 	return diags
 }
 
-// normalizeFeatureFlagFiltersForState keeps meaningful API fields so Terraform
-// can detect remote filter changes, while omitting unconfigured empty defaults
-// that PostHog adds to the response.
+// normalizeFeatureFlagFiltersForState canonicalizes the API's filters for state so
+// Terraform can detect remote changes to a flag's targeting.
+//
+// This deliberately diverges from the shared normalizeJSONForState /
+// filterToOnlyIncludeUserFields whitelist (used by survey, action, hog_function and
+// insight), which drops every field the user did not configure and so hides remote
+// drift in unconfigured fields. Here we keep every API field that carries a value and
+// drop only unconfigured empty defaults (null, {}, []) that PostHog echoes back — so a
+// meaningful UI-side edit (e.g. a property added to a group) surfaces as drift instead
+// of being silently swallowed. The divergence is feature-flag-specific; if the other
+// JSON attributes ever need the same behavior, lift this into the shared helper rather
+// than copying it.
+//
+// An unparseable prior state is treated as "nothing configured" (stateData = nil), so
+// all empty API defaults are dropped.
 func normalizeFeatureFlagFiltersForState(apiData map[string]interface{}, stateJSON string) (string, error) {
 	var stateData interface{}
 	if err := json.Unmarshal([]byte(stateJSON), &stateData); err != nil {

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -81,6 +81,74 @@ func TestFeatureFlagMapResponseToModel_NoPerpetualDiffOnKeyOrder(t *testing.T) {
 	assert.True(t, eq, "filters state must be semantically equal to config to avoid a perpetual diff")
 }
 
+func TestFeatureFlagMapResponseToModel_PreservesRemoteFilterDrift(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Filters: jsontypes.NewNormalizedValue(`{"groups":[{"rollout_percentage":100},{"properties":[{"key":"email","operator":"exact","type":"person","value":["admin@example.com"]}],"rollout_percentage":100}]}`),
+	}
+
+	resp := httpclient.FeatureFlag{
+		ID:  123,
+		Key: "create-additional-business",
+		Filters: map[string]interface{}{
+			"aggregation_group_type_index": nil,
+			"payloads":                     map[string]interface{}{},
+			"groups": []interface{}{
+				map[string]interface{}{
+					"aggregation_group_type_index": nil,
+					"properties": []interface{}{
+						map[string]interface{}{
+							"key":      "email",
+							"operator": "exact",
+							"type":     "person",
+							"value":    []interface{}{"brad@example.com"},
+						},
+					},
+					"rollout_percentage": float64(100),
+				},
+				map[string]interface{}{
+					"aggregation_group_type_index": nil,
+					"variant":                      nil,
+					"properties": []interface{}{
+						map[string]interface{}{
+							"key":      "email",
+							"operator": "exact",
+							"type":     "person",
+							"value":    []interface{}{"admin@example.com"},
+						},
+					},
+					"rollout_percentage": float64(100),
+				},
+			},
+		},
+	}
+
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.JSONEq(t, `{
+		"groups": [
+			{
+				"properties": [{
+					"key": "email",
+					"operator": "exact",
+					"type": "person",
+					"value": ["brad@example.com"]
+				}],
+				"rollout_percentage": 100
+			},
+			{
+				"properties": [{
+					"key": "email",
+					"operator": "exact",
+					"type": "person",
+					"value": ["admin@example.com"]
+				}],
+				"rollout_percentage": 100
+			}
+		]
+	}`, model.Filters.ValueString())
+}
+
 func TestFeatureFlagBuildCreateRequestSetsEnsureExperienceContinuity(t *testing.T) {
 	ops := FeatureFlagOps{}
 	model := FeatureFlagTFModel{

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -81,6 +81,48 @@ func TestFeatureFlagMapResponseToModel_NoPerpetualDiffOnKeyOrder(t *testing.T) {
 	assert.True(t, eq, "filters state must be semantically equal to config to avoid a perpetual diff")
 }
 
+// TestNormalizeFeatureFlagFiltersForState_UnparsedStateDropsEmptyDefaults pins the
+// documented fallback: when the prior state is empty or unparseable it is treated as
+// "nothing configured", so every empty API default (null, {}, []) is dropped while
+// non-empty values are kept. This is the initial-create path (state is null).
+func TestNormalizeFeatureFlagFiltersForState_UnparsedStateDropsEmptyDefaults(t *testing.T) {
+	apiData := map[string]interface{}{
+		"aggregation_group_type_index": nil,
+		"payloads":                     map[string]interface{}{},
+		"groups": []interface{}{
+			map[string]interface{}{
+				"aggregation_group_type_index": nil,
+				"variant":                      nil,
+				"properties": []interface{}{
+					map[string]interface{}{
+						"key":      "email",
+						"operator": "exact",
+						"type":     "person",
+						"value":    []interface{}{"brad@example.com"},
+					},
+				},
+				"rollout_percentage": float64(100),
+			},
+		},
+	}
+
+	for _, stateJSON := range []string{"", "not valid json"} {
+		got, err := normalizeFeatureFlagFiltersForState(apiData, stateJSON)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"groups": [{
+				"properties": [{
+					"key": "email",
+					"operator": "exact",
+					"type": "person",
+					"value": ["brad@example.com"]
+				}],
+				"rollout_percentage": 100
+			}]
+		}`, got, "stateJSON=%q", stateJSON)
+	}
+}
+
 func TestFeatureFlagMapResponseToModel_PreservesRemoteFilterDrift(t *testing.T) {
 	ops := FeatureFlagOps{}
 	model := FeatureFlagTFModel{

--- a/testacc/feature_flag_test.go
+++ b/testacc/feature_flag_test.go
@@ -114,6 +114,39 @@ func TestFeatureFlag_Filters(t *testing.T) {
 	})
 }
 
+// TestFeatureFlag_FiltersOmittedRolloutNoPerpetualDiff guards the interaction between the
+// drift-preserving normalizer (normalizeFeatureFlagFiltersForState) and semantic equality:
+// a group that omits rollout_percentage must not drift. The normalizer keeps every non-empty
+// API field, so if PostHog ever echoed a non-empty default (e.g. rollout_percentage=100) for
+// a field the config omits, that field would be stored in state and surface as a permanent
+// plan. Verified against the live API: PostHog returns the group WITHOUT rollout_percentage
+// when it is omitted, so the re-plan stays empty. This test pins that behavior.
+func TestFeatureFlag_FiltersOmittedRolloutNoPerpetualDiff(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rKey := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFeatureFlagFiltersNoRollout(rKey),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_feature_flag.test", "key", rKey),
+					resource.TestCheckResourceAttrSet("posthog_feature_flag.test", "filters"),
+				),
+			},
+			{
+				// Re-plan with the identical config whose group omits rollout_percentage. A
+				// non-empty plan would mean the normalizer kept a server-injected default.
+				Config:   testAccFeatureFlagFiltersNoRollout(rKey),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestFeatureFlag_FiltersNoPerpetualDiff is the end-to-end regression test for issue #111.
 // It configures filters as a RAW JSON string whose object keys are in a natural,
 // non-alphabetical order (key, type, operator, value) — unlike jsonencode, which sorts
@@ -484,6 +517,32 @@ resource "posthog_feature_flag" "test" {
   active = true
 
   filters = "{\"groups\":[{\"properties\":[{\"key\":\"email\",\"type\":\"person\",\"operator\":\"exact\",\"value\":[\"test@example.com\"]}],\"rollout_percentage\":100}]}"
+}
+`, key)
+}
+
+// testAccFeatureFlagFiltersNoRollout builds a config whose single group omits
+// rollout_percentage, to verify PostHog does not echo a non-empty default that the
+// drift-preserving normalizer would then surface as a perpetual diff.
+func testAccFeatureFlagFiltersNoRollout(key string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_feature_flag" "test" {
+  key    = %q
+  name   = "Filters without rollout"
+  active = true
+
+  filters = jsonencode({
+    groups = [{
+      properties = [{
+        key      = "email"
+        type     = "person"
+        operator = "exact"
+        value    = ["test@example.com"]
+      }]
+    }]
+  })
 }
 `, key)
 }


### PR DESCRIPTION
## Summary

- preserve meaningful feature flag filter fields added or changed remotely during refresh
- continue omitting unconfigured null and empty defaults returned by PostHog
- add a regression test covering a remotely added email condition in an existing group

## Problem

Feature flag reads currently normalize the API response against the JSON shape already stored in Terraform state. This suppresses PostHog response defaults, but it also removes meaningful keys that were added outside Terraform before Terraform can compare them with configuration.

For example, if a properties condition is added to an existing rollout group in PostHog, refresh stores only the previous rollout_percentage field. Terraform then cannot detect or import that targeting change.

## Fix

Use feature-flag-specific normalization that retains all non-empty API fields while omitting only unconfigured null, empty-map, and empty-list defaults. Configured empty values remain represented in state.

This complements #113, which addresses semantic JSON ordering; this PR addresses fields being omitted from refreshed state entirely.

## Test plan

- go test ./...
- go vet ./...
- go build ./...
- regression test fails on upstream main and passes with this change