### PR TITLE
feat(feature_flag): add create_usage_dashboard attribute (default false) to stop per-flag dashboard spam

### DIFF
--- a/docs/resources/feature_flag.md
+++ b/docs/resources/feature_flag.md
@@ -22,6 +22,7 @@ PostHog Feature Flag resource
 ### Optional
 
 - `active` (Boolean) Whether the feature flag is active
+- `create_usage_dashboard` (Boolean) Whether PostHog should auto-create a "Generated Dashboard: <key> Usage" dashboard when the flag is created. Defaults to `false`: PostHog's API defaults this to `true`, which silently creates one usage dashboard per flag — for Terraform-managed flag fleets that quickly clutters the dashboard list. Set to `true` to keep the API's auto-generation. Create-time only; changing it later has no effect and a usage dashboard can always be generated on demand from the flag's Usage tab.
 - `deleted` (Boolean) Whether the feature flag is soft-deleted. Terraform will restore soft-deleted flags on apply.
 - `ensure_experience_continuity` (Boolean) Whether to persist the flag across authentication steps (PostHog's UI labels this as 'Persist flag across authentication steps'). Flags with experience continuity enabled cannot be evaluated by server-side local evaluation; set this to false for flags that must be evaluated locally.
 - `filters` (String) Feature flag filters as JSON. Compared semantically, so key ordering and whitespace differences from the PostHog API do not produce a diff. Fields present in the API response but absent from this config are kept in state so remote changes surface as drift — except the top-level keys listed in `ignore_filter_fields`.

--- a/internal/httpclient/feature_flags.go
+++ b/internal/httpclient/feature_flags.go
@@ -25,6 +25,10 @@ type FeatureFlagRequest struct {
 	Tags                       []string               `json:"tags,omitempty"`
 	Deleted                    *bool                  `json:"deleted,omitempty"`
 	EnsureExperienceContinuity *bool                  `json:"ensure_experience_continuity,omitempty"`
+	// Write-only create option. PostHog's API defaults this to true, which
+	// auto-creates a "Generated Dashboard: <key> Usage" dashboard for every
+	// flag created via the API. Only sent on create; never returned by the API.
+	ShouldCreateUsageDashboard *bool `json:"_should_create_usage_dashboard,omitempty"`
 }
 
 func (c *PosthogClient) CreateFeatureFlag(ctx context.Context, projectID string, input FeatureFlagRequest) (FeatureFlag, error) {

--- a/internal/resource/feature_flag.go
+++ b/internal/resource/feature_flag.go
@@ -37,6 +37,7 @@ type FeatureFlagTFModel struct {
 	Tags                       types.Set            `tfsdk:"tags"`
 	Deleted                    types.Bool           `tfsdk:"deleted"`
 	EnsureExperienceContinuity types.Bool           `tfsdk:"ensure_experience_continuity"`
+	CreateUsageDashboard       types.Bool           `tfsdk:"create_usage_dashboard"`
 }
 
 type FeatureFlagOps struct{}
@@ -120,6 +121,14 @@ func (o FeatureFlagOps) Schema() schema.Schema {
 					core.DefaultBoolFalse{},
 				},
 			},
+			"create_usage_dashboard": schema.BoolAttribute{
+				Optional: true,
+				MarkdownDescription: "Whether PostHog should auto-create a \"Generated Dashboard: <key> Usage\" dashboard when the flag is created. " +
+					"Defaults to `false`: PostHog's API defaults this to `true`, which silently creates one usage dashboard per flag — " +
+					"for Terraform-managed flag fleets that quickly clutters the dashboard list. Set to `true` to keep the API's " +
+					"auto-generation. Create-time only; changing it later has no effect and a usage dashboard can always be generated " +
+					"on demand from the flag's Usage tab.",
+			},
 		},
 	}
 }
@@ -192,6 +201,11 @@ func (o FeatureFlagOps) BuildCreateRequest(ctx context.Context, model FeatureFla
 	// Always set deleted to false on create
 	deleted := false
 	req.Deleted = &deleted
+
+	// Suppress PostHog's auto-generated per-flag usage dashboard unless
+	// explicitly requested (the API's own default is true). Create-time only.
+	createUsageDashboard := model.CreateUsageDashboard.ValueBool()
+	req.ShouldCreateUsageDashboard = &createUsageDashboard
 
 	return req, diags
 }

--- a/internal/resource/feature_flag_test.go
+++ b/internal/resource/feature_flag_test.go
@@ -336,6 +336,43 @@ func TestFeatureFlagBuildCreateRequestOmitsEnsureExperienceContinuityWhenNull(t 
 	assert.Nil(t, req.EnsureExperienceContinuity)
 }
 
+func TestFeatureFlagBuildCreateRequestSuppressesUsageDashboardByDefault(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Key: types.StringValue("my_flag"),
+	}
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.NotNil(t, req.ShouldCreateUsageDashboard)
+	assert.False(t, *req.ShouldCreateUsageDashboard)
+}
+
+func TestFeatureFlagBuildCreateRequestAllowsUsageDashboardOptIn(t *testing.T) {
+	ops := FeatureFlagOps{}
+	model := FeatureFlagTFModel{
+		Key:                  types.StringValue("my_flag"),
+		CreateUsageDashboard: types.BoolValue(true),
+	}
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.NotNil(t, req.ShouldCreateUsageDashboard)
+	assert.True(t, *req.ShouldCreateUsageDashboard)
+}
+
+func TestFeatureFlagBuildUpdateRequestNeverSendsUsageDashboardField(t *testing.T) {
+	ops := FeatureFlagOps{}
+	plan := FeatureFlagTFModel{
+		Key:                  types.StringValue("my_flag"),
+		CreateUsageDashboard: types.BoolValue(true),
+	}
+
+	req, diags := ops.BuildUpdateRequest(context.Background(), plan, FeatureFlagTFModel{})
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.Nil(t, req.ShouldCreateUsageDashboard)
+}
+
 func TestFeatureFlagBuildUpdateRequestSetsEnsureExperienceContinuity(t *testing.T) {
 	ops := FeatureFlagOps{}
 	plan := FeatureFlagTFModel{

--- a/testacc/feature_flag_test.go
+++ b/testacc/feature_flag_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
@@ -857,4 +860,148 @@ func TestFeatureFlag_ExternalDeletion(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestFeatureFlag_CreateUsageDashboard empirically confirms the observable behavior of the
+// create_usage_dashboard attribute against the live API. PostHog's flag-create serializer
+// defaults _should_create_usage_dashboard to true, auto-creating a dashboard named
+// "Generated Dashboard: <key> Usage" in the same request. The provider defaults the attribute
+// to false and only sends the field on create.
+//
+// Two flags are created in a single apply:
+//   - default: create_usage_dashboard unset (=> false). Assert ZERO usage dashboards exist.
+//   - optin:   create_usage_dashboard = true.          Assert exactly ONE usage dashboard exists.
+//
+// The dashboard PostHog auto-creates for the opt-in flag is NOT Terraform-managed, so
+// CheckDestroy will not remove it. After asserting it exists, the final check soft-deletes it
+// via the API so the run does not orphan a dashboard in the project.
+func TestFeatureFlag_CreateUsageDashboard(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	keyDefault := acctest.RandomWithPrefix("tf-acc-test")
+	keyOptIn := acctest.RandomWithPrefix("tf-acc-test")
+
+	host := os.Getenv("POSTHOG_HOST")
+	apiKey := os.Getenv("POSTHOG_API_KEY")
+	projectID := os.Getenv("POSTHOG_PROJECT_ID")
+	client := httpclient.NewDefaultClient(host, apiKey, "acceptance-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFeatureFlagUsageDashboardPair(keyDefault, keyOptIn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_feature_flag.default", "key", keyDefault),
+					resource.TestCheckResourceAttr("posthog_feature_flag.optin", "key", keyOptIn),
+					// Default (unset => false): PostHog must NOT have auto-created a usage dashboard.
+					testCheckUsageDashboardCount(t, host, apiKey, projectID, keyDefault, 0),
+					// Opt-in (true): PostHog must have auto-created exactly one usage dashboard.
+					testCheckUsageDashboardCount(t, host, apiKey, projectID, keyOptIn, 1),
+					// Clean up the non-Terraform-managed dashboard so we don't orphan it.
+					testCleanupUsageDashboards(t, host, apiKey, projectID, &client, keyOptIn),
+				),
+			},
+		},
+	})
+}
+
+func testAccFeatureFlagUsageDashboardPair(keyDefault, keyOptIn string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_feature_flag" "default" {
+  key    = %q
+  active = true
+}
+
+resource "posthog_feature_flag" "optin" {
+  key                    = %q
+  active                 = true
+  create_usage_dashboard = true
+}
+`, keyDefault, keyOptIn)
+}
+
+// usageDashboardName is the name PostHog gives the dashboard it auto-generates for a flag.
+func usageDashboardName(flagKey string) string {
+	return fmt.Sprintf("Generated Dashboard: %s Usage", flagKey)
+}
+
+// searchUsageDashboards lists dashboards for a flag key via the raw dashboards endpoint
+// (there is no list method on the client) and returns only those whose name exactly matches
+// the auto-generated usage-dashboard name. Using ?search=<key> avoids paginating the project's
+// full dashboard list; the exact-name filter guards against fuzzy search matches.
+func searchUsageDashboards(host, apiKey, projectID, flagKey string) ([]httpclient.Dashboard, error) {
+	endpoint := fmt.Sprintf("%s/api/projects/%s/dashboards/?search=%s", host, projectID, url.QueryEscape(flagKey))
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("dashboards list returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var page struct {
+		Results []httpclient.Dashboard `json:"results"`
+	}
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, err
+	}
+
+	wantName := usageDashboardName(flagKey)
+	var matched []httpclient.Dashboard
+	for _, d := range page.Results {
+		if d.Name != nil && *d.Name == wantName {
+			matched = append(matched, d)
+		}
+	}
+	return matched, nil
+}
+
+// testCheckUsageDashboardCount asserts the number of auto-generated usage dashboards that
+// exist for a flag key.
+func testCheckUsageDashboardCount(t *testing.T, host, apiKey, projectID, flagKey string, want int) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		found, err := searchUsageDashboards(host, apiKey, projectID, flagKey)
+		if err != nil {
+			return fmt.Errorf("searching usage dashboards for %q: %w", flagKey, err)
+		}
+		if len(found) != want {
+			return fmt.Errorf("expected %d usage dashboard(s) named %q, found %d", want, usageDashboardName(flagKey), len(found))
+		}
+		t.Logf("usage dashboards for %q: found %d (want %d)", flagKey, len(found), want)
+		return nil
+	}
+}
+
+// testCleanupUsageDashboards soft-deletes any auto-generated usage dashboards for a flag key.
+// These dashboards are created by PostHog, not Terraform, so CheckDestroy will not remove them.
+func testCleanupUsageDashboards(t *testing.T, host, apiKey, projectID string, client *httpclient.PosthogClient, flagKey string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		found, err := searchUsageDashboards(host, apiKey, projectID, flagKey)
+		if err != nil {
+			return fmt.Errorf("searching usage dashboards for cleanup of %q: %w", flagKey, err)
+		}
+		for _, d := range found {
+			if _, err := client.DeleteDashboard(context.Background(), projectID, fmt.Sprintf("%d", d.ID)); err != nil {
+				return fmt.Errorf("soft-deleting orphan usage dashboard %d for %q: %w", d.ID, flagKey, err)
+			}
+			t.Logf("soft-deleted orphan usage dashboard %d (%q)", d.ID, usageDashboardName(flagKey))
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
## Problem

PostHog's feature-flag **create** API includes a write-only serializer field `_should_create_usage_dashboard` that **defaults to `true`** ([`feature_flag.py`](https://github.com/PostHog/posthog/blob/master/products/feature_flags/backend/api/feature_flag.py) — `_should_create_usage_dashboard = serializers.BooleanField(required=False, write_only=True, default=True)`). The provider doesn't send this field, so **every flag created via Terraform silently spawns a "Generated Dashboard: \<key\> Usage" dashboard** in the same request.

For IaC-managed flag fleets this adds up quickly: our project accumulated **204** such dashboards (one per applied flag, ~60/month), burying every real dashboard in the list. The PostHog UI itself made usage-dashboard creation lazy (a button on the flag's Usage tab) for exactly this reason — API/Terraform creation is the remaining path that still auto-generates.

## Change

- Add an optional `create_usage_dashboard` bool attribute to `posthog_feature_flag` (**default `false`**), sent as `_should_create_usage_dashboard` on create.
- Never sent on update (the API only honors it at creation; `omitempty` keeps PATCH payloads unchanged).
- Docs regenerated via `tools/go generate`.

Defaulting to `false` is a deliberate behavior change: declaratively-managed flags creating hidden UI artifacts violates least surprise, and the dashboard remains available on demand from the flag's Usage tab. If you'd rather preserve API parity, flipping the default to `true` is a one-line change — happy to adjust.

## Testing

- `go build ./...`, `go vet ./internal/...` clean.
- New unit tests: default suppresses (`_should_create_usage_dashboard: false` sent on create), explicit opt-in sends `true`, update requests never include the field. `go test ./internal/resource/ -run FeatureFlag` passes.
- Root-caused against a production project: flag creation and dashboard creation are 123 ms apart in the activity log, one dashboard per Terraform-created flag.