### PR TITLE
fix: compare posthog_hog_function JSON attributes semantically

### DIFF
--- a/internal/resource/hog_function.go
+++ b/internal/resource/hog_function.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -35,20 +36,20 @@ func NewHogFunction() resource.Resource {
 type HogFunctionResourceTFModel struct {
 	core.BaseStringIdentifiable
 	core.BaseProjectID
-	Type                types.String `tfsdk:"type"`
-	Name                types.String `tfsdk:"name"`
-	Description         types.String `tfsdk:"description"`
-	Enabled             types.Bool   `tfsdk:"enabled"`
-	Hog                 types.String `tfsdk:"hog"`
-	InputsJSON          types.String `tfsdk:"inputs_json"`
-	SensitiveInputsJSON types.String `tfsdk:"sensitive_inputs_json"`
-	InputsSchemaJSON    types.String `tfsdk:"inputs_schema_json"`
-	FiltersJSON         types.String `tfsdk:"filters_json"`
-	MaskingJSON         types.String `tfsdk:"masking_json"`
-	MappingsJSON        types.String `tfsdk:"mappings_json"`
-	IconURL             types.String `tfsdk:"icon_url"`
-	TemplateID          types.String `tfsdk:"template_id"`
-	ExecutionOrder      types.Int64  `tfsdk:"execution_order"`
+	Type                types.String         `tfsdk:"type"`
+	Name                types.String         `tfsdk:"name"`
+	Description         types.String         `tfsdk:"description"`
+	Enabled             types.Bool           `tfsdk:"enabled"`
+	Hog                 types.String         `tfsdk:"hog"`
+	InputsJSON          jsontypes.Normalized `tfsdk:"inputs_json"`
+	SensitiveInputsJSON jsontypes.Normalized `tfsdk:"sensitive_inputs_json"`
+	InputsSchemaJSON    jsontypes.Normalized `tfsdk:"inputs_schema_json"`
+	FiltersJSON         jsontypes.Normalized `tfsdk:"filters_json"`
+	MaskingJSON         jsontypes.Normalized `tfsdk:"masking_json"`
+	MappingsJSON        jsontypes.Normalized `tfsdk:"mappings_json"`
+	IconURL             types.String         `tfsdk:"icon_url"`
+	TemplateID          types.String         `tfsdk:"template_id"`
+	ExecutionOrder      types.Int64          `tfsdk:"execution_order"`
 }
 
 type HogFunctionOps struct{}
@@ -102,27 +103,33 @@ func (o HogFunctionOps) Schema() schema.Schema {
 				},
 			},
 			"inputs_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				MarkdownDescription: "JSON object containing the input values for the Hog function. Keys correspond to the input schema, values contain `value` and optional `templating` properties. For inputs containing secrets, use `sensitive_inputs_json` instead.",
 			},
 			"sensitive_inputs_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				Sensitive:           true,
 				MarkdownDescription: "JSON object containing sensitive input values (e.g. API keys, tokens, credentials) for the Hog function. Same format as `inputs_json`. Values are merged with `inputs_json` at apply time and redacted from plan/apply output. If the same key appears in both, `sensitive_inputs_json` takes precedence.",
 			},
 			"inputs_schema_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				MarkdownDescription: "JSON array defining custom input schema entries for the Hog function. Each entry is an object with `key`, `type`, `secret`, `required`, and other properties. Sent directly as `inputs_schema` in the API request. When using a template, this replaces the template's default schema.",
 			},
 			"filters_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				MarkdownDescription: "JSON object defining filters for when the Hog function should execute. Includes `events`, `actions`, `properties`, and `filter_test_accounts` options.",
 			},
 			"masking_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				MarkdownDescription: "JSON object configuring PII masking for the Hog function. Includes `ttl`, `threshold`, and `hash` properties.",
 			},
 			"mappings_json": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
 				Optional:            true,
 				MarkdownDescription: "JSON array of mapping configurations. Each mapping can have its own `name`, `inputs_schema`, `inputs`, and `filters`.",
 			},
@@ -344,7 +351,7 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 				diags.AddError("Failed to normalize inputs", err.Error())
 				return diags
 			}
-			model.InputsJSON = types.StringValue(normalized)
+			model.InputsJSON = jsontypes.NewNormalizedValue(normalized)
 		} else if model.SensitiveInputsJSON.IsNull() {
 			// Import case: both fields are null, populate inputs_json with all API inputs
 			normalized, err := normalizeJSONStripServerFields(resp.Inputs, "")
@@ -352,7 +359,7 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 				diags.AddError("Failed to normalize inputs", err.Error())
 				return diags
 			}
-			model.InputsJSON = types.StringValue(normalized)
+			model.InputsJSON = jsontypes.NewNormalizedValue(normalized)
 		}
 
 		// sensitive_inputs_json: do NOT update from API response. The PostHog API never
@@ -362,12 +369,12 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 		// value is always the correct value to keep in state.
 	} else {
 		if !model.InputsJSON.IsNull() {
-			model.InputsJSON = types.StringValue("{}")
+			model.InputsJSON = jsontypes.NewNormalizedValue("{}")
 		}
 		// When the API returns no inputs at all, reflect that in state so drift is
 		// surfaced correctly (the resource genuinely has no inputs configured).
 		if !model.SensitiveInputsJSON.IsNull() {
-			model.SensitiveInputsJSON = types.StringValue("{}")
+			model.SensitiveInputsJSON = jsontypes.NewNormalizedValue("{}")
 		}
 	}
 
@@ -418,12 +425,12 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 				diags.AddError("Failed to normalize inputs_schema", err.Error())
 				return diags
 			}
-			model.InputsSchemaJSON = types.StringValue(normalized)
+			model.InputsSchemaJSON = jsontypes.NewNormalizedValue(normalized)
 		}
 	} else if !model.InputsSchemaJSON.IsNull() {
-		model.InputsSchemaJSON = types.StringValue("[]")
+		model.InputsSchemaJSON = jsontypes.NewNormalizedValue("[]")
 	} else {
-		model.InputsSchemaJSON = types.StringNull()
+		model.InputsSchemaJSON = jsontypes.NewNormalizedNull()
 	}
 
 	if len(resp.Filters) > 0 {
@@ -432,11 +439,11 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 			diags.AddError("Failed to normalize filters", err.Error())
 			return diags
 		}
-		model.FiltersJSON = types.StringValue(normalized)
+		model.FiltersJSON = jsontypes.NewNormalizedValue(normalized)
 	} else if !model.FiltersJSON.IsNull() {
-		model.FiltersJSON = types.StringValue("{}")
+		model.FiltersJSON = jsontypes.NewNormalizedValue("{}")
 	} else {
-		model.FiltersJSON = types.StringNull()
+		model.FiltersJSON = jsontypes.NewNormalizedNull()
 	}
 
 	if len(resp.Masking) > 0 {
@@ -445,11 +452,11 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 			diags.AddError("Failed to normalize masking", err.Error())
 			return diags
 		}
-		model.MaskingJSON = types.StringValue(normalized)
+		model.MaskingJSON = jsontypes.NewNormalizedValue(normalized)
 	} else if !model.MaskingJSON.IsNull() {
-		model.MaskingJSON = types.StringValue("{}")
+		model.MaskingJSON = jsontypes.NewNormalizedValue("{}")
 	} else {
-		model.MaskingJSON = types.StringNull()
+		model.MaskingJSON = jsontypes.NewNormalizedNull()
 	}
 
 	// Mappings contain nested inputs and filters that need server fields stripped
@@ -459,11 +466,11 @@ func (o HogFunctionOps) MapResponseToModel(ctx context.Context, resp httpclient.
 			diags.AddError("Failed to normalize mappings", err.Error())
 			return diags
 		}
-		model.MappingsJSON = types.StringValue(normalized)
+		model.MappingsJSON = jsontypes.NewNormalizedValue(normalized)
 	} else if !model.MappingsJSON.IsNull() {
-		model.MappingsJSON = types.StringValue("[]")
+		model.MappingsJSON = jsontypes.NewNormalizedValue("[]")
 	} else {
-		model.MappingsJSON = types.StringNull()
+		model.MappingsJSON = jsontypes.NewNormalizedNull()
 	}
 
 	return diags

--- a/internal/resource/hog_function_json_test.go
+++ b/internal/resource/hog_function_json_test.go
@@ -1,0 +1,117 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hogFunctionJSONTestCases lists every hog_function attribute that holds a raw
+// JSON document, together with a config-style JSON value, a semantically equal
+// variant serialised the way the PostHog API returns it (alphabetised keys,
+// different whitespace), and a semantically different value.
+var hogFunctionJSONTestCases = []struct {
+	attribute     string
+	configJSON    string
+	reorderedJSON string
+	differentJSON string
+}{
+	{
+		attribute:     "inputs_json",
+		configJSON:    `{"pixelId":{"value":"123","templating":"hog"},"eventName":{"value":"Purchase","templating":"hog"}}`,
+		reorderedJSON: `{"eventName": {"templating": "hog", "value": "Purchase"}, "pixelId": {"templating": "hog", "value": "123"}}`,
+		differentJSON: `{"pixelId":{"value":"456","templating":"hog"},"eventName":{"value":"Purchase","templating":"hog"}}`,
+	},
+	{
+		attribute:     "sensitive_inputs_json",
+		configJSON:    `{"apiKey":{"value":"secret-token","templating":"hog"}}`,
+		reorderedJSON: `{"apiKey": {"templating": "hog", "value": "secret-token"}}`,
+		differentJSON: `{"apiKey":{"value":"other-token","templating":"hog"}}`,
+	},
+	{
+		attribute:     "filters_json",
+		configJSON:    `{"events":[{"id":"$pageview","type":"events"}],"filter_test_accounts":true}`,
+		reorderedJSON: `{"filter_test_accounts": true, "events": [{"type": "events", "id": "$pageview"}]}`,
+		differentJSON: `{"events":[{"id":"$autocapture","type":"events"}],"filter_test_accounts":true}`,
+	},
+	{
+		attribute:     "inputs_schema_json",
+		configJSON:    `[{"key":"apiKey","type":"string","secret":true,"required":true}]`,
+		reorderedJSON: `[{"required": true, "secret": true, "key": "apiKey", "type": "string"}]`,
+		differentJSON: `[{"key":"apiKey","type":"string","secret":false,"required":true}]`,
+	},
+	{
+		attribute:     "masking_json",
+		configJSON:    `{"ttl":3600,"threshold":5,"hash":"{person.id}"}`,
+		reorderedJSON: `{"hash": "{person.id}", "threshold": 5, "ttl": 3600}`,
+		differentJSON: `{"ttl":7200,"threshold":5,"hash":"{person.id}"}`,
+	},
+	{
+		attribute:     "mappings_json",
+		configJSON:    `[{"name":"Purchase","filters":{"events":[{"id":"$pageview","type":"events"}]}}]`,
+		reorderedJSON: `[{"filters": {"events": [{"type": "events", "id": "$pageview"}]}, "name": "Purchase"}]`,
+		differentJSON: `[{"name":"Checkout","filters":{"events":[{"id":"$pageview","type":"events"}]}}]`,
+	},
+}
+
+// hogFunctionJSONValue builds the given attribute's value from a raw JSON
+// string using the type declared in the schema, and requires that the type
+// supports semantic string equality. With plain types.String the framework
+// compares config and state byte-for-byte, which is exactly the perpetual-diff
+// bug from issue #120.
+func hogFunctionJSONValue(t *testing.T, attribute, rawJSON string) basetypes.StringValuableWithSemanticEquals {
+	t.Helper()
+
+	attr, ok := HogFunctionOps{}.Schema().Attributes[attribute]
+	require.True(t, ok, "attribute %s not found in schema", attribute)
+
+	strTypable, ok := attr.GetType().(basetypes.StringTypable)
+	require.True(t, ok, "attribute %s must be string-based", attribute)
+
+	value, diags := strTypable.ValueFromString(context.Background(), basetypes.NewStringValue(rawJSON))
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+
+	semantic, ok := value.(basetypes.StringValuableWithSemanticEquals)
+	require.True(t, ok,
+		"attribute %s is compared as a raw string; it must use a type with semantic JSON equality (jsontypes.Normalized) or key reordering by the API causes a perpetual diff",
+		attribute)
+
+	return semantic
+}
+
+// Semantically equal JSON (same document, different key order and whitespace,
+// as returned by the PostHog API) must compare as equal, so Terraform reports
+// no diff.
+func TestHogFunctionJSONAttributes_SemanticallyEqualJSONNoDiff(t *testing.T) {
+	for _, tc := range hogFunctionJSONTestCases {
+		t.Run(tc.attribute, func(t *testing.T) {
+			configValue := hogFunctionJSONValue(t, tc.attribute, tc.configJSON)
+			stateValue := hogFunctionJSONValue(t, tc.attribute, tc.reorderedJSON)
+
+			equal, diags := configValue.StringSemanticEquals(context.Background(), stateValue)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+			assert.True(t, equal,
+				"config %s and API-serialised %s are semantically equal and must not diff",
+				tc.configJSON, tc.reorderedJSON)
+		})
+	}
+}
+
+// Semantically different JSON must still be detected as a change.
+func TestHogFunctionJSONAttributes_SemanticallyDifferentJSONStillDiffs(t *testing.T) {
+	for _, tc := range hogFunctionJSONTestCases {
+		t.Run(tc.attribute, func(t *testing.T) {
+			configValue := hogFunctionJSONValue(t, tc.attribute, tc.configJSON)
+			changedValue := hogFunctionJSONValue(t, tc.attribute, tc.differentJSON)
+
+			equal, diags := configValue.StringSemanticEquals(context.Background(), changedValue)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+			assert.False(t, equal,
+				"%s and %s differ semantically and must produce a diff",
+				tc.configJSON, tc.differentJSON)
+		})
+	}
+}

--- a/internal/resource/hog_function_test.go
+++ b/internal/resource/hog_function_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/posthog/terraform-provider/internal/util"
 	"github.com/stretchr/testify/assert"
@@ -92,14 +92,14 @@ func TestBuildCreateRequest_MergesSensitiveInputs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			model := HogFunctionResourceTFModel{}
 			if tc.inputsJSON != "" {
-				model.InputsJSON = types.StringValue(tc.inputsJSON)
+				model.InputsJSON = jsontypes.NewNormalizedValue(tc.inputsJSON)
 			} else {
-				model.InputsJSON = types.StringNull()
+				model.InputsJSON = jsontypes.NewNormalizedNull()
 			}
 			if tc.sensitiveInputsJSON != "" {
-				model.SensitiveInputsJSON = types.StringValue(tc.sensitiveInputsJSON)
+				model.SensitiveInputsJSON = jsontypes.NewNormalizedValue(tc.sensitiveInputsJSON)
 			} else {
-				model.SensitiveInputsJSON = types.StringNull()
+				model.SensitiveInputsJSON = jsontypes.NewNormalizedNull()
 			}
 
 			req, diags := ops.BuildCreateRequest(ctx, model)
@@ -141,7 +141,7 @@ func TestBuildCreateRequest_InputsSchemaJSON(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			model := HogFunctionResourceTFModel{
-				InputsSchemaJSON: types.StringValue(tc.inputsSchemaJSON),
+				InputsSchemaJSON: jsontypes.NewNormalizedValue(tc.inputsSchemaJSON),
 			}
 
 			req, diags := ops.BuildCreateRequest(ctx, model)
@@ -158,7 +158,7 @@ func TestBuildCreateRequest_InputsSchemaJSON_Invalid(t *testing.T) {
 	ops := HogFunctionOps{}
 
 	model := HogFunctionResourceTFModel{
-		InputsSchemaJSON: types.StringValue(`not valid json`),
+		InputsSchemaJSON: jsontypes.NewNormalizedValue(`not valid json`),
 	}
 
 	_, diags := ops.BuildCreateRequest(ctx, model)
@@ -170,7 +170,7 @@ func TestBuildCreateRequest_InputsSchemaJSON_Null(t *testing.T) {
 	ops := HogFunctionOps{}
 
 	model := HogFunctionResourceTFModel{
-		InputsSchemaJSON: types.StringNull(),
+		InputsSchemaJSON: jsontypes.NewNormalizedNull(),
 	}
 
 	req, diags := ops.BuildCreateRequest(ctx, model)
@@ -184,9 +184,9 @@ func TestBuildCreateRequest_InputsSchemaWithInputsAndSensitiveInputs(t *testing.
 
 	t.Run("all three fields populate request correctly", func(t *testing.T) {
 		model := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
-			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true,"required":true}]`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string","secret":true,"required":true}]`),
 		}
 
 		req, diags := ops.BuildCreateRequest(ctx, model)
@@ -206,9 +206,9 @@ func TestBuildCreateRequest_InputsSchemaWithInputsAndSensitiveInputs(t *testing.
 
 	t.Run("schema with inputs_json only (no sensitive)", func(t *testing.T) {
 		model := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"},"region":{"value":"us-east-1"}}`),
-			SensitiveInputsJSON: types.StringNull(),
-			InputsSchemaJSON:    types.StringValue(`[{"key":"region","type":"string"}]`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"},"region":{"value":"us-east-1"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedNull(),
+			InputsSchemaJSON:    jsontypes.NewNormalizedValue(`[{"key":"region","type":"string"}]`),
 		}
 
 		req, diags := ops.BuildCreateRequest(ctx, model)
@@ -222,9 +222,9 @@ func TestBuildCreateRequest_InputsSchemaWithInputsAndSensitiveInputs(t *testing.
 
 	t.Run("schema with sensitive_inputs_json only (no inputs_json)", func(t *testing.T) {
 		model := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringNull(),
-			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
-			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+			InputsJSON:          jsontypes.NewNormalizedNull(),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string","secret":true}]`),
 		}
 
 		req, diags := ops.BuildCreateRequest(ctx, model)
@@ -239,8 +239,8 @@ func TestBuildCreateRequest_InputsSchemaWithInputsAndSensitiveInputs(t *testing.
 func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 	ctx := context.Background()
 	tests := map[string]struct {
-		inputsJSON            types.String
-		sensitiveInputsJSON   types.String
+		inputsJSON            jsontypes.Normalized
+		sensitiveInputsJSON   jsontypes.Normalized
 		respInputs            map[string]interface{}
 		expectedInputs        string
 		expectedSensitive     string
@@ -248,8 +248,8 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 		expectSensitiveIsNull bool
 	}{
 		"splits keys to original fields": {
-			inputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			sensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"secret123"}}`),
+			inputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			sensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"secret123"}}`),
 			respInputs: map[string]interface{}{
 				"url":     map[string]interface{}{"value": "https://example.com"},
 				"api_key": map[string]interface{}{"value": "secret123"},
@@ -258,8 +258,8 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 			expectedSensitive: `{"api_key":{"value":"secret123"}}`,
 		},
 		"null sensitive_inputs_json stays null": {
-			inputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			sensitiveInputsJSON: types.StringNull(),
+			inputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			sensitiveInputsJSON: jsontypes.NewNormalizedNull(),
 			respInputs: map[string]interface{}{
 				"url": map[string]interface{}{"value": "https://example.com"},
 			},
@@ -267,8 +267,8 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 			expectSensitiveIsNull: true,
 		},
 		"strips server fields from both": {
-			inputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			sensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"secret"}}`),
+			inputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			sensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"secret"}}`),
 			respInputs: map[string]interface{}{
 				"url":     map[string]interface{}{"value": "https://example.com", "bytecode": []interface{}{"_H", 1}, "order": 0},
 				"api_key": map[string]interface{}{"value": "secret", "bytecode": []interface{}{"_H", 2}, "order": 1},
@@ -277,8 +277,8 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 			expectedSensitive: `{"api_key":{"value":"secret"}}`,
 		},
 		"only sensitive_inputs_json set - must not leak into inputs_json": {
-			inputsJSON:          types.StringNull(),
-			sensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"secret123"}}`),
+			inputsJSON:          jsontypes.NewNormalizedNull(),
+			sensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"secret123"}}`),
 			respInputs: map[string]interface{}{
 				"api_key": map[string]interface{}{"value": "secret123"},
 			},
@@ -286,15 +286,15 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 			expectedSensitive:  `{"api_key":{"value":"secret123"}}`,
 		},
 		"empty resp.Inputs with only sensitive_inputs_json zeroes sensitive field": {
-			inputsJSON:          types.StringNull(),
-			sensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"secret123"}}`),
+			inputsJSON:          jsontypes.NewNormalizedNull(),
+			sensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"secret123"}}`),
 			respInputs:          map[string]interface{}{},
 			expectInputsIsNull:  true,
 			expectedSensitive:   `{}`,
 		},
 		"import: both fields null populates inputs_json with all API inputs": {
-			inputsJSON:          types.StringNull(),
-			sensitiveInputsJSON: types.StringNull(),
+			inputsJSON:          jsontypes.NewNormalizedNull(),
+			sensitiveInputsJSON: jsontypes.NewNormalizedNull(),
 			respInputs: map[string]interface{}{
 				"url":     map[string]interface{}{"value": "https://example.com"},
 				"api_key": map[string]interface{}{"value": "secret123"},
@@ -303,8 +303,8 @@ func TestMapResponseToModel_SplitsInputsBack(t *testing.T) {
 			expectSensitiveIsNull: true,
 		},
 		"duplicate key in both fields: inputs_json gets API value, sensitive_inputs_json keeps prior state": {
-			inputsJSON:          types.StringValue(`{"shared_key":{"value":"from_inputs"}}`),
-			sensitiveInputsJSON: types.StringValue(`{"shared_key":{"value":"from_sensitive"}}`),
+			inputsJSON:          jsontypes.NewNormalizedValue(`{"shared_key":{"value":"from_inputs"}}`),
+			sensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"shared_key":{"value":"from_sensitive"}}`),
 			respInputs: map[string]interface{}{
 				"shared_key": map[string]interface{}{"value": "api_value"},
 			},
@@ -353,13 +353,13 @@ func TestMapResponseToModel_InputsSchemaJSON(t *testing.T) {
 	ops := HogFunctionOps{}
 
 	tests := map[string]struct {
-		inputsSchemaJSON types.String
+		inputsSchemaJSON jsontypes.Normalized
 		respInputsSchema []map[string]interface{}
 		expectedJSON     string
 		expectNull       bool
 	}{
 		"filters to user-specified keys": {
-			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+			inputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string","secret":true}]`),
 			respInputsSchema: []map[string]interface{}{
 				{"key": "url", "type": "string", "label": "URL"},
 				{"key": "apiKey", "type": "string", "secret": true, "label": "API Key"},
@@ -368,19 +368,19 @@ func TestMapResponseToModel_InputsSchemaJSON(t *testing.T) {
 			expectedJSON: `[{"key":"apiKey","secret":true,"type":"string"}]`,
 		},
 		"null stays null on import": {
-			inputsSchemaJSON: types.StringNull(),
+			inputsSchemaJSON: jsontypes.NewNormalizedNull(),
 			respInputsSchema: []map[string]interface{}{
 				{"key": "url", "type": "string"},
 			},
 			expectNull: true,
 		},
 		"empty response with non-null model": {
-			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"}]`),
+			inputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string"}]`),
 			respInputsSchema: nil,
 			expectedJSON:     "[]",
 		},
 		"multiple user keys filtered from larger response": {
-			inputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"},{"key":"region","type":"string"}]`),
+			inputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string"},{"key":"region","type":"string"}]`),
 			respInputsSchema: []map[string]interface{}{
 				{"key": "url", "type": "string"},
 				{"key": "apiKey", "type": "string", "secret": true},
@@ -390,7 +390,7 @@ func TestMapResponseToModel_InputsSchemaJSON(t *testing.T) {
 			expectedJSON: `[{"key":"apiKey","type":"string"},{"key":"region","type":"string"}]`,
 		},
 		"API missing a user-specified key uses correct field templates": {
-			inputsSchemaJSON: types.StringValue(`[{"key":"a","type":"string"},{"key":"b","type":"number","label":"B"}]`),
+			inputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"a","type":"string"},{"key":"b","type":"number","label":"B"}]`),
 			respInputsSchema: []map[string]interface{}{
 				{"key": "b", "type": "number", "label": "B", "order": 1},
 			},
@@ -428,7 +428,7 @@ func TestMapResponseToModel_InputsSchemaJSON_InvalidState(t *testing.T) {
 	ops := HogFunctionOps{}
 
 	model := &HogFunctionResourceTFModel{
-		InputsSchemaJSON: types.StringValue(`not valid json`),
+		InputsSchemaJSON: jsontypes.NewNormalizedValue(`not valid json`),
 	}
 
 	resp := httpclient.HogFunction{
@@ -448,9 +448,9 @@ func TestMapResponseToModel_InputsSchemaWithInputsAndSensitiveInputs(t *testing.
 
 	t.Run("all three fields round-trip correctly", func(t *testing.T) {
 		model := &HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringValue(`{"apiKey":{"value":"secret-token"}}`),
-			InputsSchemaJSON:    types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"apiKey":{"value":"secret-token"}}`),
+			InputsSchemaJSON:    jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string","secret":true}]`),
 		}
 
 		resp := httpclient.HogFunction{
@@ -486,12 +486,12 @@ func TestBuildUpdateRequest_SensitiveInputs(t *testing.T) {
 
 	t.Run("removing sensitive_inputs_json excludes sensitive keys from request", func(t *testing.T) {
 		plan := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringNull(), // user removed sensitive_inputs_json
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedNull(), // user removed sensitive_inputs_json
 		}
 		state := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"secret123"}}`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"secret123"}}`),
 		}
 
 		req, diags := ops.BuildUpdateRequest(ctx, plan, state)
@@ -503,12 +503,12 @@ func TestBuildUpdateRequest_SensitiveInputs(t *testing.T) {
 
 	t.Run("updating sensitive_inputs_json merges correctly", func(t *testing.T) {
 		plan := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"new_secret"}}`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"new_secret"}}`),
 		}
 		state := HogFunctionResourceTFModel{
-			InputsJSON:          types.StringValue(`{"url":{"value":"https://example.com"}}`),
-			SensitiveInputsJSON: types.StringValue(`{"api_key":{"value":"old_secret"}}`),
+			InputsJSON:          jsontypes.NewNormalizedValue(`{"url":{"value":"https://example.com"}}`),
+			SensitiveInputsJSON: jsontypes.NewNormalizedValue(`{"api_key":{"value":"old_secret"}}`),
 		}
 
 		req, diags := ops.BuildUpdateRequest(ctx, plan, state)
@@ -527,10 +527,10 @@ func TestBuildUpdateRequest_InputsSchemaJSON(t *testing.T) {
 
 	t.Run("inputs_schema_json flows through update", func(t *testing.T) {
 		plan := HogFunctionResourceTFModel{
-			InputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string","secret":true}]`),
+			InputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string","secret":true}]`),
 		}
 		state := HogFunctionResourceTFModel{
-			InputsSchemaJSON: types.StringValue(`[{"key":"oldKey","type":"string"}]`),
+			InputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"oldKey","type":"string"}]`),
 		}
 
 		req, diags := ops.BuildUpdateRequest(ctx, plan, state)
@@ -542,10 +542,10 @@ func TestBuildUpdateRequest_InputsSchemaJSON(t *testing.T) {
 
 	t.Run("removing inputs_schema_json sends nil", func(t *testing.T) {
 		plan := HogFunctionResourceTFModel{
-			InputsSchemaJSON: types.StringNull(),
+			InputsSchemaJSON: jsontypes.NewNormalizedNull(),
 		}
 		state := HogFunctionResourceTFModel{
-			InputsSchemaJSON: types.StringValue(`[{"key":"apiKey","type":"string"}]`),
+			InputsSchemaJSON: jsontypes.NewNormalizedValue(`[{"key":"apiKey","type":"string"}]`),
 		}
 
 		req, diags := ops.BuildUpdateRequest(ctx, plan, state)


### PR DESCRIPTION
Fixes #120

## What

`posthog_hog_function`'s JSON attributes (`inputs_json`, `sensitive_inputs_json`, `inputs_schema_json`, `filters_json`, `masking_json`, `mappings_json`) were plain strings, so any formatting difference between the configured JSON and what the API returns (key order, whitespace) produced a perpetual diff on every plan.

This switches all six attributes to `jsontypes.Normalized` from terraform-plugin-framework-jsontypes, the framework's canonical way to compare JSON semantically. Semantically equal JSON no longer diffs; real changes still do.

## Tests

Unit tests cover semantic equality (reordered keys, whitespace) producing no diff and genuinely different JSON still diffing. Verified on GitHub Actions: build, lint, and unit tests pass on Terraform 1.13 and 1.14 (run on my fork before opening this PR).

Credit to @HerrNiklasRaab for the report in #120.
