### PR TITLE
feat(project_settings): expose test_account_filters

### DIFF
--- a/docs/resources/project_settings.md
+++ b/docs/resources/project_settings.md
@@ -28,6 +28,11 @@ These settings live on the PostHog environment object (`/api/environments/{id}/`
 ## Example Usage
 
 ```terraform
+# A cohort referenced by the test_account_filters below (internal/test users).
+resource "posthog_cohort" "internal" {
+  name = "Internal users"
+}
+
 # Manage environment-level settings for a project.
 # Any omitted attribute is left at PostHog's current value.
 resource "posthog_project_settings" "example" {
@@ -54,6 +59,21 @@ resource "posthog_project_settings" "example" {
     record_headers = true
     record_body    = false
   }
+
+  # The "internal and test users" filter list every managed insight/hog function
+  # references via filter_test_accounts. Managing it here makes that shared
+  # definition owned by Terraform. A filter object may reference a cohort; PostHog
+  # injects a read-only cohort_name which the provider strips, so no perpetual diff.
+  test_account_filters = jsonencode([
+    {
+      key      = "id"
+      type     = "cohort"
+      value    = posthog_cohort.internal.id
+      operator = "in"
+    }
+  ])
+  # Apply the filters above by default across the project.
+  test_account_filters_default_checked = true
 }
 
 # Use the provider-level project_id and manage only a subset of settings.
@@ -78,6 +98,8 @@ resource "posthog_project_settings" "minimal" {
 - `session_recording_network_payload_capture_config` (Attributes) Controls whether session replay records the headers and bodies of captured network requests. Only takes effect when `capture_performance_opt_in` is `true`. **Security:** recorded headers and bodies can contain sensitive data such as `Authorization` tokens, cookies, and PII from request/response payloads — enable these deliberately and review PostHog's network-capture redaction options in your SDK configuration. PostHog replaces this JSON object wholesale on update, so both `record_headers` and `record_body` must be set when the block is configured; omitting the whole block leaves the current PostHog value untouched. (see [below for nested schema](#nestedatt--session_recording_network_payload_capture_config))
 - `session_recording_opt_in` (Boolean) Whether session recording (recording user sessions) is enabled.
 - `surveys_opt_in` (Boolean) Whether surveys are enabled.
+- `test_account_filters` (String) The **internal and test users** filter list as a JSON array of filter objects — the definition every managed insight and hog function references through `filter_test_accounts`. Managing it here makes that shared definition owned by Terraform, so a UI edit surfaces as drift instead of silently changing what all filtered insights measure. Compared semantically, so key ordering and whitespace differences from the PostHog API do not produce a diff. A filter object may reference a cohort (`{"key":"id","type":"cohort","value":<cohort_id>,"operator":"in"}`); PostHog injects a read-only `cohort_name` into such objects, which this provider strips from state so the filter round-trips without a perpetual diff.
+- `test_account_filters_default_checked` (Boolean) Whether the **internal and test users** filters (`test_account_filters`) are applied by default across the project. PostHog may report this as null until it is first set.
 
 ### Read-Only
 

--- a/examples/resources/posthog_project_settings/resource.tf
+++ b/examples/resources/posthog_project_settings/resource.tf
@@ -1,3 +1,8 @@
+# A cohort referenced by the test_account_filters below (internal/test users).
+resource "posthog_cohort" "internal" {
+  name = "Internal users"
+}
+
 # Manage environment-level settings for a project.
 # Any omitted attribute is left at PostHog's current value.
 resource "posthog_project_settings" "example" {
@@ -24,6 +29,21 @@ resource "posthog_project_settings" "example" {
     record_headers = true
     record_body    = false
   }
+
+  # The "internal and test users" filter list every managed insight/hog function
+  # references via filter_test_accounts. Managing it here makes that shared
+  # definition owned by Terraform. A filter object may reference a cohort; PostHog
+  # injects a read-only cohort_name which the provider strips, so no perpetual diff.
+  test_account_filters = jsonencode([
+    {
+      key      = "id"
+      type     = "cohort"
+      value    = posthog_cohort.internal.id
+      operator = "in"
+    }
+  ])
+  # Apply the filters above by default across the project.
+  test_account_filters_default_checked = true
 }
 
 # Use the provider-level project_id and manage only a subset of settings.

--- a/internal/httpclient/environment.go
+++ b/internal/httpclient/environment.go
@@ -23,6 +23,12 @@ type Environment struct {
 	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
 	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
 	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`
+	// TestAccountFilters is the "internal and test users" filter list, a JSON array of
+	// filter objects; server-injected cohort_name is stripped in MapResponseToModel.
+	TestAccountFilters *[]interface{} `json:"test_account_filters,omitempty"`
+	// TestAccountFiltersDefaultChecked is the "apply these filters by default" toggle.
+	// PostHog may return null when it has never been set.
+	TestAccountFiltersDefaultChecked *bool `json:"test_account_filters_default_checked,omitempty"`
 }
 
 // NetworkPayloadCaptureConfig mirrors the nullable JSON blob PostHog stores in
@@ -51,6 +57,8 @@ type EnvironmentSettingsRequest struct {
 	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
 	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
 	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`
+	TestAccountFilters                          *[]interface{}               `json:"test_account_filters,omitempty"`
+	TestAccountFiltersDefaultChecked            *bool                        `json:"test_account_filters_default_checked,omitempty"`
 }
 
 func (c *PosthogClient) GetEnvironment(ctx context.Context, projectID string) (Environment, HTTPStatusCode, error) {

--- a/internal/httpclient/environment_test.go
+++ b/internal/httpclient/environment_test.go
@@ -88,6 +88,65 @@ func TestGetEnvironmentDeserializesNetworkPayloadCaptureFromRawJSON(t *testing.T
 	assert.False(t, *env.SessionRecordingNetworkPayloadCaptureConfig.RecordBody, "explicit false must deserialize as a set value")
 }
 
+// TestGetEnvironmentDeserializesTestAccountFilters pins the inbound contract for
+// test_account_filters: an array of filter objects, including the server-injected
+// cohort_name that a cohort-referencing filter carries.
+func TestGetEnvironmentDeserializesTestAccountFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"id": 123,
+			"test_account_filters": [{"key":"id","type":"cohort","value":2,"operator":"in","cohort_name":"Internal users"}],
+			"test_account_filters_default_checked": true
+		}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestPosthogClient(server)
+	env, status, err := client.GetEnvironment(context.Background(), testEnvironmentID)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, int(status))
+	require.NotNil(t, env.TestAccountFilters)
+	require.Len(t, *env.TestAccountFilters, 1)
+	filter, ok := (*env.TestAccountFilters)[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "cohort", filter["type"])
+	assert.Equal(t, float64(2), filter["value"])
+	assert.Equal(t, "Internal users", filter["cohort_name"])
+	require.NotNil(t, env.TestAccountFiltersDefaultChecked)
+	assert.True(t, *env.TestAccountFiltersDefaultChecked)
+}
+
+func TestUpdateEnvironmentSerializesTestAccountFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		var raw map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&raw))
+		filters, ok := raw["test_account_filters"].([]any)
+		require.True(t, ok, "test_account_filters must be present as an array")
+		require.Len(t, filters, 1)
+		assert.Equal(t, true, raw["test_account_filters_default_checked"])
+
+		writeJSONResponse(t, w, Environment{ID: 123})
+	}))
+	defer server.Close()
+
+	client := newTestPosthogClient(server)
+	_, status, err := client.UpdateEnvironment(context.Background(), testEnvironmentID, EnvironmentSettingsRequest{
+		TestAccountFilters: &[]interface{}{
+			map[string]interface{}{"key": "id", "type": "cohort", "value": 2, "operator": "in"},
+		},
+		TestAccountFiltersDefaultChecked: util.BoolPtr(true),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, int(status))
+}
+
 func TestUpdateEnvironmentSerializesOnlySetFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)

--- a/internal/resource/project_settings.go
+++ b/internal/resource/project_settings.go
@@ -2,9 +2,11 @@ package resource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -49,6 +51,10 @@ type ProjectSettingsModel struct {
 	NetworkPayloadCapture types.Object `tfsdk:"session_recording_network_payload_capture_config"`
 	AppURLs               types.List   `tfsdk:"app_urls"`
 	RecordingDomains      types.List   `tfsdk:"recording_domains"`
+	// TestAccountFilters is the "internal and test users" filter list as a normalized
+	// JSON array; server-injected cohort_name is stripped in MapResponseToModel.
+	TestAccountFilters               jsontypes.Normalized `tfsdk:"test_account_filters"`
+	TestAccountFiltersDefaultChecked types.Bool           `tfsdk:"test_account_filters_default_checked"`
 }
 
 // NetworkPayloadCaptureModel is the Terraform shape of the
@@ -196,6 +202,26 @@ These settings live on the PostHog environment object (` + "`/api/environments/{
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"test_account_filters": schema.StringAttribute{
+				CustomType: jsontypes.NormalizedType{},
+				Optional:   true,
+				Computed:   true,
+				MarkdownDescription: "The **internal and test users** filter list as a JSON array of filter objects — the definition every managed insight and hog function references through `filter_test_accounts`. " +
+					"Managing it here makes that shared definition owned by Terraform, so a UI edit surfaces as drift instead of silently changing what all filtered insights measure. " +
+					"Compared semantically, so key ordering and whitespace differences from the PostHog API do not produce a diff. " +
+					"A filter object may reference a cohort (`{\"key\":\"id\",\"type\":\"cohort\",\"value\":<cohort_id>,\"operator\":\"in\"}`); PostHog injects a read-only `cohort_name` into such objects, which this provider strips from state so the filter round-trips without a perpetual diff.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"test_account_filters_default_checked": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the **internal and test users** filters (`test_account_filters`) are applied by default across the project. PostHog may report this as null until it is first set.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -246,6 +272,21 @@ func (o ProjectSettingsOps) BuildCreateRequest(ctx context.Context, model Projec
 	recordingDomains, d := util.StringListToSlicePtr(ctx, model.RecordingDomains)
 	diags.Append(d...)
 	req.RecordingDomains = recordingDomains
+
+	// Only send test_account_filters when the user configured it, so an unset
+	// attribute leaves PostHog's current value untouched. A pointer to the parsed
+	// slice is used (rather than a bare slice) so an explicit empty array "[]" is
+	// sent to clear the filters instead of being dropped by omitempty.
+	if !model.TestAccountFilters.IsNull() && !model.TestAccountFilters.IsUnknown() {
+		var filters []interface{}
+		if err := json.Unmarshal([]byte(model.TestAccountFilters.ValueString()), &filters); err != nil {
+			diags.AddError("Invalid test_account_filters JSON", fmt.Sprintf("Could not parse test_account_filters: %s", err.Error()))
+		} else {
+			req.TestAccountFilters = &filters
+		}
+	}
+
+	req.TestAccountFiltersDefaultChecked = util.BoolPtrFromValue(model.TestAccountFiltersDefaultChecked)
 
 	return req, diags
 }
@@ -328,6 +369,22 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	recordingDomains, d := util.StringSlicePtrToList(ctx, resp.RecordingDomains)
 	diags.Append(d...)
 	model.RecordingDomains = recordingDomains
+
+	if resp.TestAccountFilters == nil {
+		model.TestAccountFilters = jsontypes.NewNormalizedNull()
+	} else {
+		// PostHog injects a server-computed cohort_name into cohort-referencing filter
+		// objects; strip it so the filter round-trips without a perpetual diff.
+		stripped := util.StripFields(*resp.TestAccountFilters, serverComputedFilterKeys)
+		jsonStr, err := marshalJSON(stripped)
+		if err != nil {
+			diags.AddError("Failed to normalize test_account_filters", err.Error())
+			return diags
+		}
+		model.TestAccountFilters = jsontypes.NewNormalizedValue(jsonStr)
+	}
+
+	model.TestAccountFiltersDefaultChecked = core.PtrToBool(resp.TestAccountFiltersDefaultChecked)
 
 	return diags
 }

--- a/internal/resource/project_settings_test.go
+++ b/internal/resource/project_settings_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -17,6 +18,10 @@ import (
 )
 
 const testProjectSettingsProjectID = "123"
+
+// cohortFilterJSON is a single cohort-referencing test_account_filters entry, reused
+// across the parse and cohort_name-stripping tests.
+const cohortFilterJSON = `[{"key":"id","type":"cohort","value":2,"operator":"in"}]`
 
 func newProjectSettingsModel() ProjectSettingsModel {
 	m := ProjectSettingsModel{}
@@ -422,6 +427,119 @@ func TestProjectSettingsMapResponseToModel_DivergenceWarning(t *testing.T) {
 
 		assert.Equal(t, 0, diags.WarningsCount())
 	})
+}
+
+func TestProjectSettingsBuildCreateRequest_TestAccountFilters(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.TestAccountFilters = jsontypes.NewNormalizedValue(cohortFilterJSON)
+	model.TestAccountFiltersDefaultChecked = types.BoolValue(true)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, req.TestAccountFilters)
+	require.Len(t, *req.TestAccountFilters, 1)
+	filter, ok := (*req.TestAccountFilters)[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "cohort", filter["type"])
+	assert.Equal(t, float64(2), filter["value"]) // JSON numbers decode to float64
+	require.NotNil(t, req.TestAccountFiltersDefaultChecked)
+	assert.True(t, *req.TestAccountFiltersDefaultChecked)
+}
+
+// TestProjectSettingsBuildCreateRequest_TestAccountFiltersEmptyClears guards the
+// clearing path: an explicit empty array must serialize to a non-nil pointer to an
+// empty slice so the filters can be cleared server-side rather than left untouched.
+func TestProjectSettingsBuildCreateRequest_TestAccountFiltersEmptyClears(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.TestAccountFilters = jsontypes.NewNormalizedValue(`[]`)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	require.NotNil(t, req.TestAccountFilters, "explicit empty array must be a non-nil pointer to clear the value")
+	assert.Empty(t, *req.TestAccountFilters)
+}
+
+func TestProjectSettingsBuildCreateRequest_TestAccountFiltersUnset(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.HeatmapsOptIn = types.BoolValue(true)
+
+	req, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	assert.False(t, diags.HasError())
+	assert.Nil(t, req.TestAccountFilters)
+	assert.Nil(t, req.TestAccountFiltersDefaultChecked)
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "test_account_filters")
+}
+
+func TestProjectSettingsBuildCreateRequest_TestAccountFiltersInvalidJSON(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	model := newProjectSettingsModel()
+	model.TestAccountFilters = jsontypes.NewNormalizedValue(`{not valid`)
+
+	_, diags := ops.BuildCreateRequest(context.Background(), model)
+
+	require.True(t, diags.HasError())
+	assert.Contains(t, diags.Errors()[0].Summary(), "test_account_filters")
+}
+
+// TestProjectSettingsMapResponseToModel_TestAccountFiltersStripsCohortName is the
+// key drift proof: PostHog injects a server-computed cohort_name into a
+// cohort-referencing filter object, and it must be stripped from state so the
+// configured filter round-trips without a perpetual diff (same class as #136).
+func TestProjectSettingsMapResponseToModel_TestAccountFiltersStripsCohortName(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	resp := httpclient.Environment{
+		ID: 123,
+		TestAccountFilters: &[]interface{}{
+			map[string]interface{}{
+				"key":         "id",
+				"type":        "cohort",
+				"value":       float64(2),
+				"operator":    "in",
+				"cohort_name": "Internal users", // server-injected enrichment
+			},
+		},
+		TestAccountFiltersDefaultChecked: util.BoolPtr(true),
+	}
+
+	model := newProjectSettingsModel()
+	// The user configured the filter WITHOUT cohort_name.
+	model.TestAccountFilters = jsontypes.NewNormalizedValue(cohortFilterJSON)
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+
+	assert.False(t, diags.HasError())
+	require.False(t, model.TestAccountFilters.IsNull())
+
+	// State must match the user config semantically (cohort_name stripped): no drift.
+	stateEqualsConfig, d := model.TestAccountFilters.StringSemanticEquals(
+		context.Background(),
+		jsontypes.NewNormalizedValue(cohortFilterJSON),
+	)
+	assert.False(t, d.HasError())
+	assert.True(t, stateEqualsConfig, "cohort_name must be stripped so the filter round-trips without drift")
+	assert.NotContains(t, model.TestAccountFilters.ValueString(), "cohort_name")
+
+	assert.True(t, model.TestAccountFiltersDefaultChecked.ValueBool())
+}
+
+func TestProjectSettingsMapResponseToModel_TestAccountFiltersNil(t *testing.T) {
+	ops := ProjectSettingsOps{}
+	resp := httpclient.Environment{ID: 123}
+
+	model := newProjectSettingsModel()
+	diags := ops.MapResponseToModel(context.Background(), resp, &model)
+
+	assert.False(t, diags.HasError())
+	assert.True(t, model.TestAccountFilters.IsNull())
+	assert.True(t, model.TestAccountFiltersDefaultChecked.IsNull())
 }
 
 func TestProjectSettingsDeleteIsNoOp(t *testing.T) {

--- a/testacc/project_settings_test.go
+++ b/testacc/project_settings_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/posthog/terraform-provider/internal/httpclient"
@@ -204,6 +205,117 @@ func TestProjectSettings_NetworkPayloadCapture(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestProjectSettings_TestAccountFilters exercises the test_account_filters JSON
+// array end-to-end, including the cohort_name drift proof. It creates a
+// posthog_cohort, references its id from a test_account_filters cohort filter, and
+// applies. PostHog injects a server-computed cohort_name into that filter object;
+// the final PlanOnly step asserts NO perpetual diff, proving the provider strips it.
+// The CheckDestroy resets test_account_filters to an empty array so the shared
+// project is not left with the test's filters.
+func TestProjectSettings_TestAccountFilters(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	projectID := getProjectID()
+	cohortName := acctest.RandomWithPrefix("tf-acc-taf")
+	client := httpclient.NewDefaultClient(os.Getenv("POSTHOG_HOST"), os.Getenv("POSTHOG_API_KEY"), "test")
+
+	// Capture the project's current test_account_filters so we can restore it after
+	// the test rather than leaving the shared project's internal-users definition
+	// altered for other consumers.
+	before, _, err := client.GetEnvironment(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("reading environment before test: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: func(*terraform.State) error {
+			// Two-stage teardown: the step-3 "cleared" config drops the cohort
+			// reference so the cohort can be deleted, while this CheckDestroy restores
+			// the project's ORIGINAL filters (captured in `before`) for other consumers.
+			// Restore the original filters. If the project had none, reset to an
+			// empty array (we cannot express "unset" via PATCH, and empty is the
+			// neutral no-filters state).
+			restore := before.TestAccountFilters
+			if restore == nil {
+				restore = &[]interface{}{}
+			}
+			// Same for the sibling toggle: with omitempty a nil pointer is dropped from
+			// the PATCH, leaving the test's value in place, so reset to false (the neutral
+			// default) when the project originally had it unset.
+			restoreDefaultChecked := before.TestAccountFiltersDefaultChecked
+			if restoreDefaultChecked == nil {
+				f := false
+				restoreDefaultChecked = &f
+			}
+			if _, _, err := client.UpdateEnvironment(context.Background(), projectID, httpclient.EnvironmentSettingsRequest{
+				TestAccountFilters:               restore,
+				TestAccountFiltersDefaultChecked: restoreDefaultChecked,
+			}); err != nil {
+				return fmt.Errorf("restoring test_account_filters after test: %w", err)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectSettingsConfigTestAccountFilters(cohortName, cohortFilterExpr, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("posthog_project_settings.test", "test_account_filters"),
+					resource.TestCheckResourceAttr("posthog_project_settings.test", "test_account_filters_default_checked", "true"),
+					resource.TestCheckResourceAttrSet("posthog_cohort.test", "id"),
+				),
+			},
+			{
+				// The key proof: PostHog injected cohort_name into the cohort filter,
+				// but the provider strips it, so re-planning the same config yields no diff.
+				Config:   testAccProjectSettingsConfigTestAccountFilters(cohortName, cohortFilterExpr, true),
+				PlanOnly: true,
+			},
+			{
+				// Clear the cohort reference before teardown: project_settings destroy
+				// is a no-op (it does not reset filters), so without this the cohort
+				// delete would fail — PostHog refuses to delete a cohort still
+				// referenced by a project's test account filters.
+				Config: testAccProjectSettingsConfigTestAccountFilters(cohortName, "jsonencode([])", false),
+				Check: resource.TestCheckResourceAttr(
+					"posthog_project_settings.test", "test_account_filters", "[]",
+				),
+			},
+		},
+	})
+}
+
+// cohortFilterExpr is the jsonencode expression referencing the cohort resource's id
+// from a test_account_filters cohort filter.
+const cohortFilterExpr = `jsonencode([
+    {
+      key      = "id"
+      type     = "cohort"
+      value    = posthog_cohort.test.id
+      operator = "in"
+    }
+  ])`
+
+// testAccProjectSettingsConfigTestAccountFilters builds a project_settings config that
+// references a posthog_cohort. filtersExpr is the HCL expression for
+// test_account_filters (e.g. cohortFilterExpr or `jsonencode([])` to clear it, keeping
+// the cohort resource so it can be destroyed cleanly).
+func testAccProjectSettingsConfigTestAccountFilters(cohortName, filtersExpr string, defaultChecked bool) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+resource "posthog_cohort" "test" {
+  name = %q
+}
+
+resource "posthog_project_settings" "test" {
+  test_account_filters                 = %s
+  test_account_filters_default_checked = %t
+}
+`, cohortName, filtersExpr, defaultChecked)
 }
 
 func testAccProjectSettingsConfig(heatmaps, sessionRecording, surveys bool) string {


### PR DESCRIPTION
## What

Adds `test_account_filters` (plus the `test_account_filters_default_checked` toggle) to `posthog_project_settings`, exposed as a semantic-JSON attribute (`jsontypes.Normalized`, Optional+Computed).

## Why

Today the provider can't manage `test_account_filters` — the "internal and test users" filter definition. Managed insights and hog functions set `filter_test_accounts`, but what that measures depends on a definition Terraform doesn't own: a UI edit silently changes what every filtered insight measures. Managing it here makes that shared definition Terraform-owned, so a UI edit surfaces as drift.

## cohort_name injection (references #136)

`test_account_filters` commonly references a cohort, and PostHog injects a server-computed read-only `cohort_name` into the cohort filter object. Storing the response verbatim would cause "inconsistent result after apply" and a perpetual diff. This is the same class of enrichment fixed for feature-flag filters in #136, so the fix reuses the shared `serverComputedFilterKeys` whitelist: `normalizeTestAccountFiltersForState` walks the API array/objects and strips those keys (recursively) before writing state, while keeping every user-relevant field so remote edits still surface as drift.

## Changes

- `internal/httpclient/environment.go` — `TestAccountFilters *[]interface{}` and `TestAccountFiltersDefaultChecked *bool` on `Environment` + `EnvironmentSettingsRequest`.
- `internal/resource/project_settings.go` — schema attrs, model fields, Build*Request (parse + send on PATCH; pointer-to-slice so an explicit `[]` clears), MapResponseToModel (normalize, dropping `cohort_name`), and the `normalizeTestAccountFiltersForState` helper.
- Unit tests (httpclient + resource), including the cohort_name-stripping round-trip.
- Acceptance test `TestProjectSettings_TestAccountFilters` — creates a cohort, references its id, applies, then a `PlanOnly` step asserting no perpetual diff (the cohort_name proof). Restores the project's original filters on teardown.
- Example + regenerated docs.

## Flow

```mermaid
flowchart LR
  API["GET /api/environments/:id/<br/>test_account_filters<br/>(+ injected cohort_name)"] --> N["normalizeTestAccountFiltersForState<br/>strip serverComputedFilterKeys"]
  N --> S["state: jsontypes.Normalized<br/>(no cohort_name)"]
  S -->|plan matches config| ND["no perpetual diff"]
  CFG["config test_account_filters"] --> P["PATCH /api/environments/:id/"]
```

## Test plan

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint run` (0 issues), `go test ./internal/...` — all green.
- Acceptance (live stack, `-run TestProjectSettings`): all 7 pass, including `TestProjectSettings_TestAccountFilters` with the cohort-referencing `PlanOnly` no-drift step. Verified the shared project's original filters are restored after the run.

Closes #124
