### PR TITLE
docs(hog_function): manage error-tracking alerts via internal_destination (#131)

### DIFF
--- a/examples/error-tracking-alerts/main.tf
+++ b/examples/error-tracking-alerts/main.tf
@@ -1,0 +1,135 @@
+terraform {
+  required_providers {
+    posthog = {
+      source = "posthog/posthog"
+    }
+  }
+}
+
+provider "posthog" {
+  # Configuration can be provided via:
+  # - Environment variables: POSTHOG_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST
+  # - Or explicitly in the provider block:
+  # api_key    = "your-api-key"
+  # project_id = "12345"
+  # host       = "https://us.posthog.com"  # Optional, defaults to US cloud
+}
+
+# ---------------------------------------------------------------------------
+# Error tracking alerts (issue #131)
+#
+# PostHog error-tracking alerts are just Hog functions of
+# `type = "internal_destination"` that subscribe to one of PostHog's internal
+# error-tracking events and forward it to a destination (Slack, webhook, ...).
+#
+# There is no dedicated resource: the EXISTING `posthog_hog_function` resource
+# already models every field an alert needs, so you can manage error-tracking
+# alerts as code today.
+#
+# The internal events you can subscribe to:
+#   - $error_tracking_issue_created   (a brand-new issue was seen)
+#   - $error_tracking_issue_reopened  (a resolved issue started erroring again)
+#   - $error_tracking_issue_spiking   (an issue's volume spiked)
+#
+# The alert is wired up with three pieces:
+#   1. type        = "internal_destination"
+#   2. filters_json subscribing to the internal event above
+#   3. template_id + inputs_json selecting and configuring the destination
+# ---------------------------------------------------------------------------
+
+# Example 1: Slack alert on newly created error-tracking issues.
+#
+# Uses the built-in Slack destination template (`template-slack`). The
+# `slack_workspace` input references an existing PostHog Slack integration by
+# its numeric ID (find it under Data pipelines -> Sources / the integrations
+# API). The PostHog app must be installed in the workspace and, for private
+# channels, be a member of the channel.
+resource "posthog_hog_function" "error_issue_created_slack" {
+  name        = "Error tracking: new issue -> Slack"
+  description = "Posts to Slack whenever a new error-tracking issue is created"
+  type        = "internal_destination"
+  enabled     = true
+  template_id = "template-slack"
+
+  # Subscribe to the internal error-tracking event. Swap the id to
+  # "$error_tracking_issue_reopened" or "$error_tracking_issue_spiking" to
+  # alert on those lifecycle events instead.
+  filters_json = jsonencode({
+    events = [{
+      id   = "$error_tracking_issue_created"
+      type = "events"
+    }]
+  })
+
+  inputs_json = jsonencode({
+    # Reference an existing Slack integration by its numeric ID.
+    slack_workspace = {
+      value = 1
+    }
+    # Channel ID (e.g. "C0123ABC") is preferred; "#channel-name" also works.
+    channel = {
+      value = "#error-tracking"
+    }
+    blocks = {
+      value = [
+        {
+          type = "section"
+          text = {
+            type = "mrkdwn"
+            text = ":rotating_light: *New error-tracking issue:* {event.properties.name}"
+          }
+        },
+        {
+          type = "actions"
+          elements = [{
+            type = "button"
+            text = {
+              type = "plain_text"
+              text = "View issue in PostHog"
+            }
+            url = "{event.properties.issue_url}"
+          }]
+        }
+      ]
+      templating = "hog"
+    }
+  })
+}
+
+# Example 2: Generic webhook alert on newly created error-tracking issues.
+#
+# Uses the built-in HTTP Webhook template (`template-webhook`). This variant
+# needs no external integration - just a URL - which makes it the most portable
+# way to fan alerts out to PagerDuty, Opsgenie, a Lambda, etc.
+resource "posthog_hog_function" "error_issue_created_webhook" {
+  name        = "Error tracking: new issue -> webhook"
+  description = "POSTs to a webhook whenever a new error-tracking issue is created"
+  type        = "internal_destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  filters_json = jsonencode({
+    events = [{
+      id   = "$error_tracking_issue_created"
+      type = "events"
+    }]
+  })
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/hooks/posthog-error-tracking"
+      templating = "hog"
+    }
+    method = {
+      value = "POST"
+    }
+    body = {
+      value = {
+        issue_id = "{event.properties.issue_id}"
+        name     = "{event.properties.name}"
+        event    = "{event.event}"
+      }
+      templating = "hog"
+    }
+  })
+}

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -254,6 +255,91 @@ func TestHogFunction_AlertWebhookIntegration(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestHogFunction_ErrorTrackingAlert proves that PostHog error-tracking alerts
+// (issue #131) can be managed today with the existing posthog_hog_function
+// resource - no new resource required. An error-tracking alert is simply a Hog
+// function of type "internal_destination" whose filters subscribe to one of the
+// internal error-tracking events ($error_tracking_issue_created / _reopened /
+// _spiking) and which forwards to a destination (here: the hermetic webhook
+// template, which only needs a URL).
+//
+// The second step is PlanOnly and asserts an empty plan, proving there is no
+// perpetual diff after apply (the server enriches filters with `source` and
+// `bytecode`, which the provider strips/normalizes away).
+func TestHogFunction_ErrorTrackingAlert(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHogFunctionDestroy,
+		Steps: []resource.TestStep{
+			// Create the internal_destination alert.
+			{
+				Config: testAccHogFunctionErrorTrackingAlert(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "type", "internal_destination"),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "id"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "filters_json"),
+					// The subscription event is what makes this an error-tracking alert.
+					resource.TestMatchResourceAttr("posthog_hog_function.test", "filters_json",
+						regexp.MustCompile(`\$error_tracking_issue_created`)),
+				),
+			},
+			// Re-plan with the same config: must be a no-op (no perpetual diff).
+			{
+				Config:   testAccHogFunctionErrorTrackingAlert(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccHogFunctionErrorTrackingAlert(name string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+# Error-tracking alert: an internal_destination Hog function subscribing to the
+# internal $error_tracking_issue_created event and forwarding to a webhook.
+resource "posthog_hog_function" "test" {
+  name        = %q
+  description = "Alert on newly created error-tracking issues"
+  type        = "internal_destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  filters_json = jsonencode({
+    events = [{
+      id   = "$error_tracking_issue_created"
+      type = "events"
+    }]
+  })
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/hooks/posthog-error-tracking"
+      templating = "hog"
+    }
+    method = {
+      value = "POST"
+    }
+    body = {
+      value = {
+        issue_id = "{event.properties.issue_id}"
+        name     = "{event.properties.name}"
+        event    = "{event.event}"
+      }
+      templating = "hog"
+    }
+  })
+}
+`, name)
 }
 
 // TestHogFunction_SensitiveInputs tests creating a hog function with both


### PR DESCRIPTION
## Summary

Error-tracking alerts are achievable today via `posthog_hog_function` (`type = "internal_destination"`) — **no new resource required.**

A PostHog error-tracking alert is just a Hog function of `type = "internal_destination"` whose `filters` subscribe to one of the internal error-tracking events and forward to a destination (Slack, webhook, ...):

- `$error_tracking_issue_created`
- `$error_tracking_issue_reopened`
- `$error_tracking_issue_spiking`

Every field an alert needs (`type`, `filters_json`, `template_id`, `inputs_json`, `enabled`, ...) is already modeled by the existing `posthog_hog_function` resource, so this maps 1:1 with no schema change.

```mermaid
flowchart LR
  ETI["Error-tracking issue<br/>created / reopened / spiking"] -->|emits internal event| HF
  subgraph HF["posthog_hog_function (existing resource)"]
    T["type = internal_destination"]
    F["filters_json &rarr; events:<br/>$error_tracking_issue_created"]
    D["template_id + inputs_json<br/>(Slack / webhook)"]
  end
  HF -->|forwards| DEST["Slack channel / webhook endpoint"]
```

## What's here

- **Example** — `examples/error-tracking-alerts/main.tf`: a narrated `internal_destination` Hog function alerting on `$error_tracking_issue_created`, with a realistic **Slack** variant (referencing a Slack integration by ID) and a portable **webhook** variant. Comments show how to swap to `_reopened` / `_spiking`.
- **Acceptance test** — `TestHogFunction_ErrorTrackingAlert` in `testacc/hog_function_test.go`: creates an `internal_destination` Hog function subscribing to `$error_tracking_issue_created` via the hermetic **webhook** template, asserts `type` / `filters_json`, and a **PlanOnly** step proves there is **no perpetual diff** after apply. `CheckDestroy` cleans up.
- No resource/schema changes — `make generate` is a no-op for docs.

## Proof

Verified live against a local PostHog stack:

- The exact working create body for an error-tracking-alert Hog function returns `HTTP 201` with `type = internal_destination` and filters subscribing to `$error_tracking_issue_created`.
- Acceptance test result:

```
--- PASS: TestHogFunction_ErrorTrackingAlert (3.51s)
PASS
ok  github.com/posthog/terraform-provider/testacc
```

  (apply + PlanOnly no-drift + destroy, all green)

## Gates

- `gofmt` clean, `go build ./...` OK, `go vet ./internal/...` OK
- `golangci-lint run ./internal/... ./testacc/...` → **0 issues**
- `go test ./internal/...` (unit) → all pass

Closes #131
