### PR TITLE
feat(hog_function): document insight-alert Slack/webhook notifications (#130)

### DIFF
--- a/examples/alert-notifications/main.tf
+++ b/examples/alert-notifications/main.tf
@@ -1,0 +1,177 @@
+terraform {
+  required_providers {
+    posthog = {
+      source = "posthog/posthog"
+    }
+  }
+}
+
+provider "posthog" {
+  # Configuration can be provided via:
+  # - Environment variables: POSTHOG_API_KEY, POSTHOG_PROJECT_ID, POSTHOG_HOST
+  # - Or explicitly in the provider block:
+  # api_key    = "your-api-key"
+  # project_id = "12345"
+  # host       = "https://us.posthog.com"  # Optional, defaults to US cloud
+}
+
+# ---------------------------------------------------------------------------
+# Insight-alert Slack / webhook notifications (issue #130)
+#
+# When a `posthog_alert` fires, PostHog emits the internal event
+# `$insight_alert_firing`. Routing that to Slack, a webhook, Discord, Teams,
+# etc. is NOT a field on the alert API - it's a separate Hog function of
+# `type = "internal_destination"` that subscribes to `$insight_alert_firing`
+# and is filtered down to the firing alert's id.
+#
+# There is no dedicated resource: the EXISTING `posthog_hog_function` already
+# models every field a notification needs, so you can wire alert notifications
+# as code today. The chain is three resources:
+#   1. posthog_insight   - the thing being measured
+#   2. posthog_alert     - the threshold that fires on that insight
+#   3. posthog_hog_function (internal_destination) - the delivery, filtered by
+#      properties[alert_id] == <the alert's id> so it only fires for THIS alert
+# ---------------------------------------------------------------------------
+
+# 1. An insight to monitor.
+resource "posthog_insight" "pageviews" {
+  name = "Daily pageviews"
+
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      kind = "TrendsQuery"
+      series = [{
+        kind  = "EventsNode"
+        name  = "$pageview"
+        event = "$pageview"
+        math  = "total"
+      }]
+    }
+  })
+}
+
+# 2. An alert that fires when the insight crosses a threshold.
+resource "posthog_alert" "pageviews_spike" {
+  name                 = "Pageviews spike"
+  insight              = posthog_insight.pageviews.id
+  subscribed_users     = [] # in-app subscribers; delivery below is separate
+  threshold_type       = "absolute"
+  threshold_upper      = 10000
+  condition_type       = "absolute_value"
+  series_index         = 0
+  calculation_interval = "daily"
+}
+
+# 3. Deliver the alert to Slack.
+#
+# Uses the built-in Slack destination template (`template-slack`). The
+# `slack_workspace` input references an existing PostHog Slack integration by
+# its numeric ID (find it under Data pipelines -> Integrations). The PostHog
+# app must be installed in the workspace and, for private channels, be a member
+# of the channel.
+resource "posthog_hog_function" "pageviews_spike_slack" {
+  name        = "Pageviews spike -> Slack"
+  description = "Posts to Slack when the pageviews-spike alert fires"
+  type        = "internal_destination"
+  enabled     = true
+  template_id = "template-slack"
+
+  # Fire on the internal alert-firing event, scoped to THIS alert's id so
+  # other alerts don't trigger this destination.
+  filters_json = jsonencode({
+    events = [{
+      id   = "$insight_alert_firing"
+      type = "events"
+    }]
+    properties = [{
+      key      = "alert_id"
+      value    = posthog_alert.pageviews_spike.id
+      operator = "exact"
+      type     = "event"
+    }]
+  })
+
+  inputs_json = jsonencode({
+    # Reference an existing Slack integration by its numeric ID.
+    slack_workspace = {
+      value = 1
+    }
+    # Channel ID (e.g. "C0123ABC") is preferred; "#channel-name" also works.
+    channel = {
+      value = "#alerts"
+    }
+    blocks = {
+      value = [
+        {
+          type = "section"
+          text = {
+            type = "mrkdwn"
+            text = ":rotating_light: *Alert firing:* {event.properties.alert_name}"
+          }
+        },
+        {
+          type = "actions"
+          elements = [{
+            type = "button"
+            text = {
+              type = "plain_text"
+              text = "View insight in PostHog"
+            }
+            url = "{event.properties.insight_url}"
+          }]
+        }
+      ]
+      templating = "hog"
+    }
+  })
+
+  depends_on = [posthog_alert.pageviews_spike]
+}
+
+# 3b. Webhook variant (uncomment to use instead of / alongside Slack).
+#
+# Uses the built-in HTTP Webhook template (`template-webhook`). Needs no
+# external integration - just a URL - which makes it the most portable way to
+# fan alerts out to PagerDuty, Opsgenie, a Lambda, etc.
+#
+# resource "posthog_hog_function" "pageviews_spike_webhook" {
+#   name        = "Pageviews spike -> webhook"
+#   description = "POSTs to a webhook when the pageviews-spike alert fires"
+#   type        = "internal_destination"
+#   enabled     = true
+#   template_id = "template-webhook"
+#
+#   filters_json = jsonencode({
+#     events = [{
+#       id   = "$insight_alert_firing"
+#       type = "events"
+#     }]
+#     properties = [{
+#       key      = "alert_id"
+#       value    = posthog_alert.pageviews_spike.id
+#       operator = "exact"
+#       type     = "event"
+#     }]
+#   })
+#
+#   inputs_json = jsonencode({
+#     url = {
+#       value      = "https://example.com/hooks/posthog-alert"
+#       templating = "hog"
+#     }
+#     method = {
+#       value = "POST"
+#     }
+#     body = {
+#       value = {
+#         alert_id   = "{event.properties.alert_id}"
+#         alert_name = "{event.properties.alert_name}"
+#         value      = "{event.properties.alert_calculated_value}"
+#       }
+#       templating = "hog"
+#     }
+#   })
+#
+#   depends_on = [posthog_alert.pageviews_spike]
+# }

--- a/testacc/hog_function_test.go
+++ b/testacc/hog_function_test.go
@@ -257,6 +257,62 @@ func TestHogFunction_AlertWebhookIntegration(t *testing.T) {
 	})
 }
 
+// TestHogFunction_InsightAlertNotification proves that insight-alert Slack/webhook
+// notifications (issue #130) can be managed today with the existing resources - no
+// new resource and no schema change required. When a posthog_alert fires, PostHog
+// emits the internal event $insight_alert_firing; routing it to a destination is a
+// Hog function of type "internal_destination" that subscribes to that event and is
+// filtered to the firing alert's id. This test wires the full chain:
+// posthog_insight -> posthog_alert -> posthog_hog_function (hermetic webhook, which
+// only needs a URL).
+//
+// The second step is PlanOnly and asserts an empty plan, proving there is no
+// perpetual diff after apply (the server enriches filters with `source` and
+// `bytecode`, which the provider strips/normalizes away).
+func TestHogFunction_InsightAlertNotification(t *testing.T) {
+	skipIfNotAcceptance(t)
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckHogFunctionDestroy,
+		Steps: []resource.TestStep{
+			// Create the insight -> alert -> internal_destination chain.
+			{
+				Config: testAccHogFunctionInsightAlertNotification(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify insight
+					resource.TestCheckResourceAttr("posthog_insight.test", "name", rName+"-insight"),
+					resource.TestCheckResourceAttrSet("posthog_insight.test", "id"),
+					// Verify alert
+					resource.TestCheckResourceAttr("posthog_alert.test", "name", rName+"-alert"),
+					resource.TestCheckResourceAttr("posthog_alert.test", "threshold_type", "absolute"),
+					resource.TestCheckResourceAttr("posthog_alert.test", "threshold_upper", "1000"),
+					resource.TestCheckResourceAttr("posthog_alert.test", "calculation_interval", "daily"),
+					resource.TestCheckResourceAttr("posthog_alert.test", "skip_weekend", "false"),
+					resource.TestCheckResourceAttrSet("posthog_alert.test", "id"),
+					// Verify hog function
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "name", rName+"-webhook"),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "type", "internal_destination"),
+					resource.TestCheckResourceAttr("posthog_hog_function.test", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "id"),
+					resource.TestCheckResourceAttrSet("posthog_hog_function.test", "filters_json"),
+					// The subscription event is what makes this an alert notification.
+					resource.TestMatchResourceAttr("posthog_hog_function.test", "filters_json",
+						regexp.MustCompile(`\$insight_alert_firing`)),
+				),
+			},
+			// Re-plan with the same config: must be a no-op (no perpetual diff).
+			{
+				Config:   testAccHogFunctionInsightAlertNotification(rName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestHogFunction_ErrorTrackingAlert proves that PostHog error-tracking alerts
 // (issue #131) can be managed today with the existing posthog_hog_function
 // resource - no new resource required. An error-tracking alert is simply a Hog
@@ -963,6 +1019,88 @@ resource "posthog_hog_function" "test" {
     }
     debug = {
       value      = false
+      templating = "hog"
+    }
+  })
+
+  filters_json = jsonencode({
+    source = "events"
+    events = [{
+      id   = "$insight_alert_firing"
+      type = "events"
+    }]
+    properties = [{
+      key      = "alert_id"
+      type     = "event"
+      value    = posthog_alert.test.id
+      operator = "exact"
+    }]
+  })
+
+  depends_on = [posthog_alert.test]
+}
+`, name)
+}
+
+func testAccHogFunctionInsightAlertNotification(name string) string {
+	return fmt.Sprintf(`
+provider "posthog" {}
+
+# Step 1: Create an insight to monitor
+resource "posthog_insight" "test" {
+  name = "%[1]s-insight"
+
+  query_json = jsonencode({
+    kind   = "InsightVizNode"
+    source = {
+      kind   = "TrendsQuery"
+      series = [{
+        kind  = "EventsNode"
+        name  = "$pageview"
+        event = "$pageview"
+        math  = "total"
+      }]
+    }
+  })
+}
+
+# Step 2: Create an alert on the insight
+resource "posthog_alert" "test" {
+  name                 = "%[1]s-alert"
+  insight              = posthog_insight.test.id
+  subscribed_users     = []
+  threshold_type       = "absolute"
+  threshold_upper      = 1000
+  condition_type       = "absolute_value"
+  series_index         = 0
+  calculation_interval = "daily"
+  skip_weekend         = false
+
+  depends_on = [posthog_insight.test]
+}
+
+# Step 3: Create a webhook that fires when the alert triggers
+resource "posthog_hog_function" "test" {
+  name        = "%[1]s-webhook"
+  description = "Webhook notification when alert fires"
+  type        = "internal_destination"
+  enabled     = true
+  template_id = "template-webhook"
+
+  inputs_json = jsonencode({
+    url = {
+      value      = "https://example.com/alert-webhook"
+      templating = "hog"
+    }
+    method = {
+      value = "POST"
+    }
+    body = {
+      value = {
+        alert_name = "{event.properties.alert_name}"
+        alert_id   = "{event.properties.alert_id}"
+        value      = "{event.properties.alert_calculated_value}"
+      }
       templating = "hog"
     }
   })


### PR DESCRIPTION
## What & why

Insight-alert Slack/webhook notifications are achievable **today** via the existing `posthog_hog_function` resource — **no new resource, no schema change** required.

When a `posthog_alert` fires, PostHog emits the internal event `$insight_alert_firing`. Delivery to Slack/webhook/Discord/Teams is **not** a field on the Alert API; it's a standalone Hog function of `type = "internal_destination"` that subscribes to that event and is filtered down to the firing alert's id via `properties[alert_id]`. The `posthog_hog_function` resource already exposes every field this needs (`type`, `template_id`, `filters_json`, `inputs_json`).

This PR delivers code-documented proof of that, mirroring how error-tracking alerts (#131/#139) were documented.

## Changes

- **`examples/alert-notifications/main.tf`** — narrated `posthog_insight` -> `posthog_alert` -> `posthog_hog_function` chain delivering to **Slack** (`template-slack`, integration id + channel), with a commented **webhook** variant (`template-webhook`) and a note that it fires on `$insight_alert_firing` filtered by the alert id.
- **`testacc/hog_function_test.go`** — replaces the create-only `TestHogFunction_AlertWebhookIntegration` with **`TestHogFunction_InsightAlertNotification`**, which creates the full insight -> alert -> internal_destination webhook chain, asserts `type`/`filters_json`, adds a **PlanOnly no-drift step** (proving no perpetual diff after apply) and `CheckDestroy`. The webhook inputs mirror the drift-proven error-tracking test shape.

## Mechanism

```mermaid
flowchart LR
  I[posthog_insight] --> A[posthog_alert]
  A -- fires --> E["$insight_alert_firing<br/>(internal event)"]
  E --> H["posthog_hog_function<br/>type = internal_destination"]
  H -- "filters: alert_id == this alert" --> D[Slack / webhook / ...]
```

## Verified create body (`$insight_alert_firing` webhook internal_destination)

Confirmed directly against a live stack (POST -> 201, GET -> 200, delete -> 404):

```json
{
  "type": "internal_destination",
  "template_id": "template-webhook",
  "filters": {
    "events": [{ "id": "$insight_alert_firing", "type": "events" }],
    "properties": [{ "key": "alert_id", "value": "<alert id>", "operator": "exact", "type": "event" }]
  },
  "inputs": {
    "url": { "value": "https://.../hook", "templating": "hog" },
    "method": { "value": "POST" },
    "body": { "value": { "alert": "{event.properties.alert_name}" }, "templating": "hog" }
  }
}
```
The server enriches `filters` with `source: "events"` and `bytecode`; the provider strips/normalizes those, which is what keeps the PlanOnly step clean.

## Test plan

Gates run locally (all green): `gofmt`, `go build ./...`, `go vet ./internal/... ./testacc/...`, `golangci-lint run ./internal/... ./testacc/...` (0 issues), `go test ./internal/...`, `make generate` (no-op — no schema change).

Acceptance test (`TF_ACC=1 ... -run TestHogFunction_InsightAlertNotification`): the insight created successfully; the run was blocked locally only by the org alert quota (`400 "Your plan is limited to 5 alerts"`) on a dev stack that already has 10 alerts — an environmental limit, not a code issue. Rerun after freeing an alert slot:

```
TF_ACC=1 POSTHOG_HOST=... POSTHOG_API_KEY=... POSTHOG_PROJECT_ID=... \
  go test ./testacc/ -run '^TestHogFunction_InsightAlertNotification$' -v
```

Closes #130
