### PR TITLE
feat: claim access control rules for Terraform on refresh

### DIFF
--- a/internal/httpclient/access_control_management.go
+++ b/internal/httpclient/access_control_management.go
@@ -1,0 +1,46 @@
+package httpclient
+
+import (
+	"context"
+	"fmt"
+)
+
+// ManagerTerraform is the value PostHog stores on rules this provider owns.
+const ManagerTerraform = "terraform"
+
+// AccessControlClaimRequest addresses one rule the same way its unique constraint does.
+// A nil ManagedBy releases the rule instead of claiming it.
+type AccessControlClaimRequest struct {
+	Resource           string  `json:"resource"`
+	ResourceID         *string `json:"resource_id,omitempty"`
+	Role               *string `json:"role,omitempty"`
+	OrganizationMember *string `json:"organization_member,omitempty"`
+	ManagedBy          *string `json:"managed_by"`
+}
+
+type AccessControlClaimResponse struct {
+	ManagedBy *string `json:"managed_by"`
+	ManagedAt *string `json:"managed_at"`
+}
+
+// ClaimAccessControl tells PostHog that this provider owns the rule.
+//
+// Terraform only writes a rule when that rule changed, so a rule that is already correct is
+// never written and would never be recorded as ours. Refresh is the one point that touches every
+// managed rule on every plan, so ownership is asserted from Read instead of from the writes.
+func (c *PosthogClient) ClaimAccessControl(ctx context.Context, projectID string, input AccessControlClaimRequest) (AccessControlClaimResponse, HTTPStatusCode, error) {
+	managedBy := ManagerTerraform
+	input.ManagedBy = &managedBy
+	return c.setAccessControlManager(ctx, projectID, input)
+}
+
+// ReleaseAccessControl gives the rule back, so PostHog stops refusing changes to it.
+func (c *PosthogClient) ReleaseAccessControl(ctx context.Context, projectID string, input AccessControlClaimRequest) (AccessControlClaimResponse, HTTPStatusCode, error) {
+	input.ManagedBy = nil
+	return c.setAccessControlManager(ctx, projectID, input)
+}
+
+func (c *PosthogClient) setAccessControlManager(ctx context.Context, projectID string, input AccessControlClaimRequest) (AccessControlClaimResponse, HTTPStatusCode, error) {
+	path := fmt.Sprintf("/api/projects/%s/access_control_management/", projectID)
+	return doPut[AccessControlClaimResponse](c, ctx, path, input)
+}

--- a/internal/httpclient/access_control_management_test.go
+++ b/internal/httpclient/access_control_management_test.go
@@ -1,0 +1,34 @@
+package httpclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/posthog/terraform-provider/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// A release is expressed as an explicit null. `omitempty` on ManagedBy would drop the key, the
+// API would read the body as a claim, and a released rule would stay locked forever.
+func TestAccessControlClaimRequest_ReleaseSendsExplicitNull(t *testing.T) {
+	body, err := json.Marshal(AccessControlClaimRequest{
+		Resource:   "dashboard",
+		ResourceID: util.StringPtr("42"),
+		ManagedBy:  nil,
+	})
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"resource":"dashboard","resource_id":"42","managed_by":null}`, string(body))
+}
+
+func TestAccessControlClaimRequest_OmitsUnsetTargets(t *testing.T) {
+	managedBy := ManagerTerraform
+	body, err := json.Marshal(AccessControlClaimRequest{
+		Resource:  "feature_flag",
+		Role:      util.StringPtr("role-1"),
+		ManagedBy: &managedBy,
+	})
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"resource":"feature_flag","role":"role-1","managed_by":"terraform"}`, string(body))
+}

--- a/internal/resource/access_control.go
+++ b/internal/resource/access_control.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/posthog/terraform-provider/internal/httpclient"
 	"github.com/posthog/terraform-provider/internal/resource/core"
 )
@@ -223,11 +224,39 @@ func (o AccessControlOps) Read(ctx context.Context, client httpclient.PosthogCli
 	targetID := model.buildExpectedID(projectID)
 	for _, ac := range result.AccessControls {
 		if ac.BuildCompositeID(projectID) == targetID {
+			claimAccessControl(ctx, client, projectID, model)
 			return ac, status, nil
 		}
 	}
 
 	return httpclient.AccessControl{}, http.StatusNotFound, fmt.Errorf("access control not found for %s", targetID)
+}
+
+func claimAccessControl(ctx context.Context, client httpclient.PosthogClient, projectID string, model AccessControlTFModel) {
+	req := buildAccessControlRequest(model)
+	ClaimRuleForTerraform(ctx, client, projectID, httpclient.AccessControlClaimRequest{
+		Resource:           req.Resource,
+		ResourceID:         req.ResourceID,
+		Role:               req.Role,
+		OrganizationMember: req.OrganizationMember,
+	})
+}
+
+// ClaimRuleForTerraform records that this provider owns the rule, so PostHog can refuse edits
+// made anywhere else. Refresh runs on every plan and covers rules that never diff, which the
+// writes do not.
+//
+// Failure is logged and ignored on purpose. The endpoint only exists on newer PostHog versions,
+// and self-hosted instances upgrade on their own schedule; a plan must keep working against an
+// instance that has never heard of it.
+func ClaimRuleForTerraform(ctx context.Context, client httpclient.PosthogClient, projectID string, claim httpclient.AccessControlClaimRequest) {
+	if _, status, err := client.ClaimAccessControl(ctx, projectID, claim); err != nil {
+		tflog.Debug(ctx, "could not claim access control rule for Terraform", map[string]any{
+			"resource": claim.Resource,
+			"status":   status,
+			"error":    err.Error(),
+		})
+	}
 }
 
 func (o AccessControlOps) Update(ctx context.Context, client httpclient.PosthogClient, model AccessControlTFModel, req httpclient.AccessControlRequest) (httpclient.AccessControl, httpclient.HTTPStatusCode, error) {

--- a/internal/resource/project_default_access.go
+++ b/internal/resource/project_default_access.go
@@ -112,7 +112,14 @@ func (o ProjectDefaultAccessOps) Create(ctx context.Context, client httpclient.P
 }
 
 func (o ProjectDefaultAccessOps) Read(ctx context.Context, client httpclient.PosthogClient, model ProjectDefaultAccessModel) (httpclient.ProjectAccessControlListResponse, httpclient.HTTPStatusCode, error) {
-	return client.GetProjectAccessControls(ctx, model.GetEffectiveProjectID())
+	result, status, err := client.GetProjectAccessControls(ctx, model.GetEffectiveProjectID())
+	if err == nil {
+		// The singleton rule this resource owns: the project's own default, with no target
+		ClaimRuleForTerraform(ctx, client, model.GetEffectiveProjectID(), httpclient.AccessControlClaimRequest{
+			Resource: "project",
+		})
+	}
+	return result, status, err
 }
 
 func (o ProjectDefaultAccessOps) Update(ctx context.Context, client httpclient.PosthogClient, model ProjectDefaultAccessModel, req httpclient.ProjectAccessControlRequest) (httpclient.ProjectAccessControlListResponse, httpclient.HTTPStatusCode, error) {

--- a/internal/resource/project_member.go
+++ b/internal/resource/project_member.go
@@ -179,6 +179,11 @@ func (o ProjectMemberOps) Read(ctx context.Context, client httpclient.PosthogCli
 	expectedID := model.buildCompositeID(projectID)
 	for _, ac := range result.AccessControls {
 		if ac.BuildCompositeID(projectID) == expectedID {
+			ClaimRuleForTerraform(ctx, client, projectID, httpclient.AccessControlClaimRequest{
+				Resource:           "project",
+				Role:               ac.Role,
+				OrganizationMember: ac.OrganizationMember,
+			})
 			return ac, status, nil
 		}
 	}


### PR DESCRIPTION
## Problem

PostHog can now refuse changes to access control rules that Terraform manages ([PostHog/posthog#83256](https://github.com/PostHog/posthog/pull/83256)). It needs to know which rules those are, and the provider is the only thing that knows.

Writes alone cannot tell it. Terraform writes a rule only when that rule changed, so a rule that is already correct is never written. Those stable rules are exactly the ones a customer wants protected, and they would stay unprotected forever.

## Changes

- `ClaimAccessControl` and `ReleaseAccessControl` call PostHog's new `access_control_management` endpoint.
- `Read` claims the rule for three resources: `posthog_access_control`, `posthog_project_member`, and `posthog_project_default_access`.
- Refresh runs on every plan and covers rules with no diff, so one `terraform plan` claims a customer's whole existing estate.

A failed claim is logged at debug level and ignored. The endpoint exists only on newer PostHog versions, and self-hosted instances upgrade on their own schedule, so a plan has to keep working against an instance that has never heard of it.

No schema change. Practitioners write no new configuration.

Release is exported but not called from any resource. Terraform never runs provider code for `terraform state rm`, which is the case that strands a rule, so release stays an API affordance for now.

## How did you test this code?

`go build ./...` and `go test ./internal/...` pass. I (actually Claude) did not run the acceptance tests, which need a live PostHog instance with the matching backend change merged.

Two new tests cover the one thing that fails silently: a release must serialize `managed_by` as an explicit null. Adding `omitempty` to that field would drop the key, PostHog would read the body as a claim, and a released rule would stay locked forever.

One pre-existing failure is unrelated: `TestSleep/completes_after_duration` in `internal/httpclient/middleware` asserts a sleep duration within 10% and is timing-sensitive.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this alongside the PostHog-side change. Read the two together: neither does anything alone.

We considered stamping ownership from the `GET` that `Read` already makes, which would need no provider change. That over-claims: the list endpoint returns every rule for an object, not the one this resource owns, so a plan would lock rules a person created by hand. The explicit claim names the exact rule instead.

Merge the PostHog change first. Until it ships, every claim from this provider gets a 404 and is ignored.
