### PR TITLE
feat(project_settings): add anonymize_ips attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **`posthog_project_settings`:** New `anonymize_ips` attribute - manages the "Discard client IP data" project setting (`/api/environments/{id}/`), previously only editable from the UI. ([#146](https://github.com/PostHog/terraform-provider-posthog/issues/146))
 - **New Resource:** `posthog_logs_alert` - Threshold-based alerting on logs, with severity, service, and attribute filters, repeat-breach thresholds, and quiet hours (snoozing and notification destinations are managed as code). Window length and count limits are enforced by PostHog and reported on apply; the provider only rejects configurations PostHog would silently reshape.
 - **New Resource:** `posthog_logs_alert_destination` - Slack, webhook, and Microsoft Teams notification destinations for a `posthog_logs_alert`. PostHog has no update endpoint for destinations, so every attribute forces replacement. `slack_channel_name` is write-only: PostHog uses it to label the destination and never stores it, so it is never read back and an imported destination has it unset.
 - **`posthog_alert`:** New `schedule_restriction` attribute for quiet hours - blocked local time windows during which the alert is not evaluated. Window length and count limits are enforced by PostHog and reported on apply; the provider only rejects configurations PostHog would silently reshape.

--- a/docs/resources/project_settings.md
+++ b/docs/resources/project_settings.md
@@ -45,6 +45,8 @@ resource "posthog_project_settings" "example" {
   autocapture_web_vitals_opt_in = false
   cookieless_server_hash_mode   = 0 # 0=disabled, 1=stateless, 2=stateful
 
+  anonymize_ips = false
+
   # Authorized URLs / permitted domains (toolbar + project domain allowlist).
   app_urls = ["https://app.example.com", "https://www.example.com"]
   # Authorized domains for session replay.
@@ -87,6 +89,7 @@ resource "posthog_project_settings" "minimal" {
 
 ### Optional
 
+- `anonymize_ips` (Boolean) Whether to discard the client IP address at ingestion (shown in PostHog as **Discard client IP data**). Enabling this degrades IP-based event matching for destinations that rely on it (for example Meta Conversions API), since `$ip` is never stored.
 - `app_urls` (List of String) The project's authorized domains — shown in PostHog settings as **Web analytics domains** (and used as the toolbar's Authorized URLs). These are the domains tracked in web analytics and where the toolbar is enabled. Maps to the team `app_urls` field. Wildcards are not allowed; order is preserved.
 - `autocapture_exceptions_opt_in` (Boolean) Whether exception autocapture is enabled.
 - `autocapture_web_vitals_opt_in` (Boolean) Whether web vitals autocapture is enabled.

--- a/examples/resources/posthog_project_settings/resource.tf
+++ b/examples/resources/posthog_project_settings/resource.tf
@@ -15,6 +15,8 @@ resource "posthog_project_settings" "example" {
   autocapture_web_vitals_opt_in = false
   cookieless_server_hash_mode   = 0 # 0=disabled, 1=stateless, 2=stateful
 
+  anonymize_ips = false
+
   # Authorized URLs / permitted domains (toolbar + project domain allowlist).
   app_urls = ["https://app.example.com", "https://www.example.com"]
   # Authorized domains for session replay.

--- a/internal/httpclient/environment.go
+++ b/internal/httpclient/environment.go
@@ -20,6 +20,7 @@ type Environment struct {
 	CookielessServerHashMode                    *int64                       `json:"cookieless_server_hash_mode,omitempty"`
 	AutocaptureWebVitalsOptIn                   *bool                        `json:"autocapture_web_vitals_opt_in,omitempty"`
 	CapturePerformanceOptIn                     *bool                        `json:"capture_performance_opt_in,omitempty"`
+	AnonymizeIps                                *bool                        `json:"anonymize_ips,omitempty"`
 	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
 	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
 	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`
@@ -54,6 +55,7 @@ type EnvironmentSettingsRequest struct {
 	CookielessServerHashMode                    *int64                       `json:"cookieless_server_hash_mode,omitempty"`
 	AutocaptureWebVitalsOptIn                   *bool                        `json:"autocapture_web_vitals_opt_in,omitempty"`
 	CapturePerformanceOptIn                     *bool                        `json:"capture_performance_opt_in,omitempty"`
+	AnonymizeIps                                *bool                        `json:"anonymize_ips,omitempty"`
 	SessionRecordingNetworkPayloadCaptureConfig *NetworkPayloadCaptureConfig `json:"session_recording_network_payload_capture_config,omitempty"`
 	AppURLs                                     *[]string                    `json:"app_urls,omitempty"`
 	RecordingDomains                            *[]string                    `json:"recording_domains,omitempty"`

--- a/internal/httpclient/environment_test.go
+++ b/internal/httpclient/environment_test.go
@@ -30,6 +30,7 @@ func TestGetEnvironment(t *testing.T) {
 			SurveysOptIn:               util.BoolPtr(false),
 			CookielessServerHashMode:   util.Int64Ptr(2),
 			AutocaptureWebVitalsOptIn:  util.BoolPtr(true),
+			AnonymizeIps:               util.BoolPtr(true),
 		})
 	}))
 	defer server.Close()
@@ -52,6 +53,8 @@ func TestGetEnvironment(t *testing.T) {
 	assert.Equal(t, int64(2), *env.CookielessServerHashMode)
 	require.NotNil(t, env.AutocaptureWebVitalsOptIn)
 	assert.True(t, *env.AutocaptureWebVitalsOptIn)
+	require.NotNil(t, env.AnonymizeIps)
+	assert.True(t, *env.AnonymizeIps)
 }
 
 func TestGetEnvironmentDeserializesNetworkPayloadCaptureFromRawJSON(t *testing.T) {

--- a/internal/resource/project_settings.go
+++ b/internal/resource/project_settings.go
@@ -47,6 +47,7 @@ type ProjectSettingsModel struct {
 	CookielessServerHashMode   types.Int64  `tfsdk:"cookieless_server_hash_mode"`
 	AutocaptureWebVitalsOptIn  types.Bool   `tfsdk:"autocapture_web_vitals_opt_in"`
 	CapturePerformanceOptIn    types.Bool   `tfsdk:"capture_performance_opt_in"`
+	AnonymizeIps               types.Bool   `tfsdk:"anonymize_ips"`
 	// NetworkPayloadCapture holds a NetworkPayloadCaptureModel object.
 	NetworkPayloadCapture types.Object `tfsdk:"session_recording_network_payload_capture_config"`
 	AppURLs               types.List   `tfsdk:"app_urls"`
@@ -164,6 +165,14 @@ These settings live on the PostHog environment object (` + "`/api/environments/{
 					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"anonymize_ips": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether to discard the client IP address at ingestion (shown in PostHog as **Discard client IP data**). Enabling this degrades IP-based event matching for destinations that rely on it (for example Meta Conversions API), since `$ip` is never stored.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"session_recording_network_payload_capture_config": schema.SingleNestedAttribute{
 				Optional: true,
 				Computed: true,
@@ -235,6 +244,7 @@ func (o ProjectSettingsOps) BuildCreateRequest(ctx context.Context, model Projec
 		SurveysOptIn:               util.BoolPtrFromValue(model.SurveysOptIn),
 		AutocaptureWebVitalsOptIn:  util.BoolPtrFromValue(model.AutocaptureWebVitalsOptIn),
 		CapturePerformanceOptIn:    util.BoolPtrFromValue(model.CapturePerformanceOptIn),
+		AnonymizeIps:               util.BoolPtrFromValue(model.AnonymizeIps),
 		CookielessServerHashMode:   util.Int64PtrFromValue(model.CookielessServerHashMode),
 	}
 
@@ -326,6 +336,9 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	if util.BoolDiverged(model.CapturePerformanceOptIn, resp.CapturePerformanceOptIn) {
 		ignored = append(ignored, "capture_performance_opt_in")
 	}
+	if util.BoolDiverged(model.AnonymizeIps, resp.AnonymizeIps) {
+		ignored = append(ignored, "anonymize_ips")
+	}
 	if networkPayloadCaptureDiverged(ctx, model.NetworkPayloadCapture, resp.SessionRecordingNetworkPayloadCaptureConfig) {
 		ignored = append(ignored, "session_recording_network_payload_capture_config")
 	}
@@ -347,6 +360,7 @@ func (o ProjectSettingsOps) MapResponseToModel(ctx context.Context, resp httpcli
 	model.SurveysOptIn = core.PtrToBool(resp.SurveysOptIn)
 	model.AutocaptureWebVitalsOptIn = core.PtrToBool(resp.AutocaptureWebVitalsOptIn)
 	model.CapturePerformanceOptIn = core.PtrToBool(resp.CapturePerformanceOptIn)
+	model.AnonymizeIps = core.PtrToBool(resp.AnonymizeIps)
 	model.CookielessServerHashMode = util.PtrToInt64(resp.CookielessServerHashMode)
 
 	if resp.SessionRecordingNetworkPayloadCaptureConfig == nil {

--- a/internal/resource/project_settings_test.go
+++ b/internal/resource/project_settings_test.go
@@ -38,6 +38,7 @@ func TestProjectSettingsBuildCreateRequest_AllFields(t *testing.T) {
 	model.SurveysOptIn = types.BoolValue(false)
 	model.CookielessServerHashMode = types.Int64Value(2)
 	model.AutocaptureWebVitalsOptIn = types.BoolValue(true)
+	model.AnonymizeIps = types.BoolValue(true)
 
 	req, diags := ops.BuildCreateRequest(context.Background(), model)
 
@@ -54,6 +55,8 @@ func TestProjectSettingsBuildCreateRequest_AllFields(t *testing.T) {
 	assert.Equal(t, int64(2), *req.CookielessServerHashMode)
 	require.NotNil(t, req.AutocaptureWebVitalsOptIn)
 	assert.True(t, *req.AutocaptureWebVitalsOptIn)
+	require.NotNil(t, req.AnonymizeIps)
+	assert.True(t, *req.AnonymizeIps)
 }
 
 // TestProjectSettingsBuildCreateRequest_ZeroValues guards the zero-value path:
@@ -92,6 +95,7 @@ func TestProjectSettingsBuildCreateRequest_SubsetSet(t *testing.T) {
 	assert.Nil(t, req.SurveysOptIn)
 	assert.Nil(t, req.CookielessServerHashMode)
 	assert.Nil(t, req.AutocaptureWebVitalsOptIn)
+	assert.Nil(t, req.AnonymizeIps, "unset fields must serialize as nil (omitted)")
 }
 
 // TestProjectSettingsBuildCreateRequest_EmptyListClears guards the clearing path:
@@ -255,6 +259,7 @@ func TestProjectSettingsMapResponseToModel_AllFields(t *testing.T) {
 		SurveysOptIn:               util.BoolPtr(false),
 		CookielessServerHashMode:   util.Int64Ptr(1),
 		AutocaptureWebVitalsOptIn:  util.BoolPtr(true),
+		AnonymizeIps:               util.BoolPtr(true),
 	}
 
 	model := newProjectSettingsModel()
@@ -268,6 +273,7 @@ func TestProjectSettingsMapResponseToModel_AllFields(t *testing.T) {
 	assert.False(t, model.SurveysOptIn.ValueBool())
 	assert.Equal(t, int64(1), model.CookielessServerHashMode.ValueInt64())
 	assert.True(t, model.AutocaptureWebVitalsOptIn.ValueBool())
+	assert.True(t, model.AnonymizeIps.ValueBool())
 }
 
 // TestProjectSettingsMapResponseToModel_ZeroValues ensures a returned 0 / false
@@ -304,6 +310,7 @@ func TestProjectSettingsMapResponseToModel_NilFieldsBecomeNull(t *testing.T) {
 	assert.True(t, model.SurveysOptIn.IsNull())
 	assert.True(t, model.CookielessServerHashMode.IsNull())
 	assert.True(t, model.AutocaptureWebVitalsOptIn.IsNull())
+	assert.True(t, model.AnonymizeIps.IsNull())
 }
 
 func TestProjectSettingsMapResponseToModel_NetworkPayloadCapturePresent(t *testing.T) {
@@ -388,6 +395,19 @@ func TestProjectSettingsMapResponseToModel_DivergenceWarning(t *testing.T) {
 
 		require.Equal(t, 1, diags.WarningsCount())
 		assert.Contains(t, diags.Warnings()[0].Detail(), "capture_performance_opt_in")
+	})
+
+	t.Run("anonymize_ips diverged", func(t *testing.T) {
+		model := newProjectSettingsModel()
+		model.AnonymizeIps = types.BoolValue(true)
+
+		diags := ops.MapResponseToModel(context.Background(), httpclient.Environment{
+			ID:           123,
+			AnonymizeIps: util.BoolPtr(false),
+		}, &model)
+
+		require.Equal(t, 1, diags.WarningsCount())
+		assert.Contains(t, diags.Warnings()[0].Detail(), "anonymize_ips")
 	})
 
 	t.Run("unparseable configured object counts as diverged", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `posthog_project_settings` covers the capture opt-ins (heatmaps, session recording, surveys, etc.) but not the "Discard client IP data" toggle, so it had to be flipped by hand in the UI.
- Adds `anonymize_ips` following the existing pattern in this resource: `AnonymizeIps *bool` on `Environment` / `EnvironmentSettingsRequest`, the schema attribute, create/update wiring, and the plan-gated divergence warning if PostHog silently ignores it for a project's plan.
- Docs and the example config are regenerated/updated to match.

Closes #146

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/...` (full suite, including new coverage for `anonymize_ips` in both `internal/httpclient` and `internal/resource`)
- [x] `make generate` (docs regenerated, diff limited to the new attribute)
- [ ] Acceptance tests (`make testacc`) not run - no live PostHog API credentials in this environment